### PR TITLE
WIP: CI/CD Workflow

### DIFF
--- a/packs/cicd/actions/README.md
+++ b/packs/cicd/actions/README.md
@@ -1,0 +1,5 @@
+# actions
+
+The actions folder contains action scripts and metadata files. See [Actions](http://docs.stackstorm.com/actions.html)
+and [Workflows](http://docs.stackstorm.com/workflows.html) for specifics on writing actions. Note that the lib sub-folder
+is always available for access for an action script.

--- a/packs/cicd/actions/canary_deploy_ac.yaml
+++ b/packs/cicd/actions/canary_deploy_ac.yaml
@@ -1,0 +1,27 @@
+---
+  name: deploy
+  runner_type: action-chain
+  description: 'Deploy canary pipeline (ActionChain)'
+  enabled: true
+  entry_point: workflows/ac/deploy.yaml
+  parameters:
+    project:
+      type: string
+      description: 'Name of the project to be built (must match CI Project Name)'
+      required: true
+    branch:
+      type: string
+      description: Branch to build
+      required: true
+    url:
+      type: string
+      description: Location of the URL holding with Git Data
+      required: true
+    commit:
+      type: string
+      description: Specific commit to package up
+      required: true
+    production:
+      type: string
+      description: 'Deploy to production or not (True/False)'
+      default: false

--- a/packs/cicd/actions/canary_deploy_ac.yaml
+++ b/packs/cicd/actions/canary_deploy_ac.yaml
@@ -1,27 +1,27 @@
 ---
-  name: deploy
-  runner_type: action-chain
-  description: 'Deploy canary pipeline (ActionChain)'
-  enabled: true
-  entry_point: workflows/ac/deploy.yaml
-  parameters:
-    project:
-      type: string
-      description: 'Name of the project to be built (must match CI Project Name)'
-      required: true
-    branch:
-      type: string
-      description: Branch to build
-      required: true
-    url:
-      type: string
-      description: Location of the URL holding with Git Data
-      required: true
-    commit:
-      type: string
-      description: Specific commit to package up
-      required: true
-    production:
-      type: string
-      description: 'Deploy to production or not (True/False)'
-      default: false
+name: deploy
+runner_type: action-chain
+description: Deploy canary pipeline (ActionChain)
+enabled: true
+entry_point: 'workflows/ac/deploy.yaml'
+parameters:
+  project:
+    type: string
+    description: Name of the project to be deployed (must match CI Project Name)
+    required: true
+    position: 1
+  version:
+    type: string
+    description: Version of the project to deploy
+    required: true
+    position: 2
+  app_role:
+    type: string
+    description: Application server role to deploy code to
+    default: app
+    position: 3
+  production:
+    type: string
+    description: 'Deploy to production (default: false)'
+    default: 'false'
+    position: 4

--- a/packs/cicd/actions/canary_deploy_mistral.yaml
+++ b/packs/cicd/actions/canary_deploy_mistral.yaml
@@ -1,0 +1,24 @@
+---
+name: canary.deploy.mistral
+pack: cicd
+runner_type: mistral-v2
+description: "Deploy Canary Pipeline"
+enabled: false
+entry_point: workflows/mistral/canary.yaml
+parameters:
+  workflow:
+    type: string
+    default: cicd.canary.deploy
+    immutable: true
+  project:
+    type: string
+  branch:
+    type: string
+    default: master
+  url:
+    type: string
+  commit:
+    type: string
+  production:
+    type: string
+    default: false

--- a/packs/cicd/actions/canary_publish_apt_package_ac.yaml
+++ b/packs/cicd/actions/canary_publish_apt_package_ac.yaml
@@ -1,0 +1,24 @@
+---
+  name: publish_apt_package
+  runner_type: action-chain
+  description: Build an APT package from Canary Pipeline (ActionChain)
+  enabled: true
+  entry_point: workflows/ac/publish_apt_package.yaml
+  parameters:
+    project:
+      type: string
+      description: 'Name of the project to be built (must match CI Project Name)'
+      required: true
+    branch:
+      type: string
+      description: Branch to build
+      required: true
+    url:
+      type: string
+      description: Location of the URL holding with Git Data
+      required: true
+    commit:
+      type: string
+      description: Specific commit to package up
+      required: true
+

--- a/packs/cicd/actions/canary_publish_apt_package_mistral.yaml
+++ b/packs/cicd/actions/canary_publish_apt_package_mistral.yaml
@@ -1,0 +1,21 @@
+---
+name: canary.publish_apt_package.mistral
+pack: cicd
+runner_type: mistral-v2
+description: "Build an APT Package from Canary Pipeline"
+enabled: false
+entry_point: workflows/mistral/canary.yaml
+parameters:
+  workflow:
+    type: string
+    default: cicd.canary.publish_apt_package
+    immutable: true
+  project:
+    type: string
+  branch:
+    type: string
+    default: master
+  url:
+    type: string
+  commit:
+    type: string

--- a/packs/cicd/actions/rm.yaml
+++ b/packs/cicd/actions/rm.yaml
@@ -1,0 +1,16 @@
+# Chose to do this here as opposed to generic `linux` pack. Too destructive until
+# we have better controls in place.
+---
+name: cleanup
+description: Remote runner to cleanup after self
+runner_type: run-remote
+enabled: true
+entry_point: ''
+parameters:
+  path:
+    type: string
+    description: '** WARNING: DESTRUCTIVE ** Files or Directory to cleanup after completion.'
+    required: true
+  cmd:
+    default: "rm -rf {{path}}"
+    immutable: true

--- a/packs/cicd/actions/setup.sh
+++ b/packs/cicd/actions/setup.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cd $1
+
+script/setup

--- a/packs/cicd/actions/setup.yaml
+++ b/packs/cicd/actions/setup.yaml
@@ -1,0 +1,15 @@
+# Chose to do this here as opposed to generic `linux` pack. Too destructive until
+# we have better controls in place.
+---
+name: setup
+description: Remote runner to run application setup scripts
+runner_type: run-remote
+enabled: true
+entry_point: 'setup.sh'
+parameters:
+  # AS 'dir' makes weird things happen
+  path:
+    type: string
+    description: Directory where application bootstrap exists
+    required: true
+    position: 1

--- a/packs/cicd/actions/workflows/ac/deploy.yaml
+++ b/packs/cicd/actions/workflows/ac/deploy.yaml
@@ -1,0 +1,58 @@
+---
+  chain:
+    # This could use a better logic test here... maybe a better way to do this? #
+    -
+      name: query_if_production_deploy
+      ref: core.local
+      params:
+        cmd: '[ "{{production}}" = "true" ]'
+      on-success: get_production_version
+      on-failure: get_canary_version
+    -
+      name: get_production_version
+      ref: core.local
+      params:
+        cmd: 'echo get production version'
+      on-success: get_production_hosts
+    -
+      name: get_production_hosts
+      ref: core.local
+      params:
+        cmd: 'echo get production hosts'
+      on-success: update_production_version
+    -
+      name: update_production_version
+      ref: core.local
+      params:
+        cmd: 'echo update production version'
+      on-success: run_puppet_on_production_hosts
+    -
+      name: run_puppet_on_production_hosts
+      ref: core.local
+      params:
+        cmd: 'echo run puppet on production hosts'
+    -
+      name: get_canary_version
+      ref: core.local
+      params:
+        cmd: 'echo get canary version'
+      on-success: get_canary_hosts
+    -
+      name: get_canary_hosts
+      ref: core.local
+      params:
+        cmd: 'echo get canary hosts'
+      on-success: update_canary_version
+    -
+      name: update_canary_version
+      ref: core.local
+      params:
+        cmd: 'echo update canary version'
+      on-success: run_puppet_on_canary_hosts
+    -
+      name: run_puppet_on_canary_hosts
+      ref: core.local
+      params:
+        cmd: 'echo run puppet on canary hosts'
+  default: query_if_production_deploy
+

--- a/packs/cicd/actions/workflows/ac/deploy.yaml
+++ b/packs/cicd/actions/workflows/ac/deploy.yaml
@@ -1,58 +1,113 @@
 ---
   chain:
-    # This could use a better logic test here... maybe a better way to do this? #
+    # Non-ideal logic test, but helps keep things DRY. Still could
+    # stand a bit more consolidation
     -
       name: query_if_production_deploy
       ref: core.local
       params:
-        cmd: '[ "{{production}}" = "true" ]'
+        cmd: '"{{production}}" = "true"'
+      on-success: deploy_production
+      on-failure: deploy_canary
+
+    ## Begin Production Workflow ##
+    -
+      name: deploy_production
+      ref: slack.post_message
+      params:
+        message: "Beginning deployment of {{project}}-{{version}} to production..."
+        channel: '#bot-testing'
       on-success: get_production_version
-      on-failure: get_canary_version
     -
       name: get_production_version
-      ref: core.local
+      ref: consul.get
       params:
-        cmd: 'echo get production version'
+        key: "{{project}}::version"
       on-success: get_production_hosts
     -
       name: get_production_hosts
-      ref: core.local
+      ref: consul.query_service
       params:
-        cmd: 'echo get production hosts'
+        service: "{{project}}"
+        tag: "{{app_role}}"
       on-success: update_production_version
     -
       name: update_production_version
-      ref: core.local
+      ref: consul.put
       params:
-        cmd: 'echo update production version'
-      on-success: run_puppet_on_production_hosts
+        key: "{{project}}::version"
+        value: "{{version}}"
+      on-success: update_application_on_production_hosts
     -
-      name: run_puppet_on_production_hosts
-      ref: core.local
+      name: update_application_on_production_hosts
+      ref: debian.apt_get_update_and_install
       params:
-        cmd: 'echo run puppet on production hosts'
+        package: "{{project}}"
+        version: "{{version}}"
+        hosts: "{{get_production_hosts.result}}"
+      on-success: notify_successful_production_deployment
+      on-failure: notify_unsuccessful_production_deployment
+    -
+      name: notify_unsuccessful_production_deployment
+      ref: slack.post_message
+      params:
+        message: "Something went wrong with deployment... rolling back..."
+        channel: '#bot-testing'
+    -
+      name: notify_successful_production_deployment
+      ref: slack.post_message
+      params:
+        message: "SUCCESS!! {{project}}-{{version}} has been deployed to production!"
+        channel: '#bot-testing'
+    ## End Production Workflow ##
+
+    ## Begin Canary Workflow ##
+    -
+      name: deploy_canary
+      ref: slack.post_message
+      params:
+        message: "Beginning deployment of {{project}}-{{version}} to canary..."
+        channel: '#bot-testing'
+      on-success: get_canary_version
     -
       name: get_canary_version
-      ref: core.local
+      ref: consul.get
       params:
-        cmd: 'echo get canary version'
+        key: "{{project}}::canary_version"
       on-success: get_canary_hosts
     -
       name: get_canary_hosts
-      ref: core.local
+      ref: consul.query_service
       params:
-        cmd: 'echo get canary hosts'
+        service: "{{project}}"
+        tag: "canary_{{app_role}}"
       on-success: update_canary_version
     -
       name: update_canary_version
-      ref: core.local
+      ref: consul.put
       params:
-        cmd: 'echo update canary version'
-      on-success: run_puppet_on_canary_hosts
+        key: "{{project}}::canary_version"
+        value: "{{version}}"
+      on-success: update_application_on_canary_hosts
     -
-      name: run_puppet_on_canary_hosts
-      ref: core.local
+      name: update_application_on_canary_hosts
+      ref: debian.apt_get_update_and_install
       params:
-        cmd: 'echo run puppet on canary hosts'
+        package: "{{project}}"
+        version: "{{version}}"
+        hosts: "{{get_canary_hosts.result}}"
+      on-success: notify_successful_canary_deployment
+      on-failure: notify_unsuccessful_canary_deployment
+    -
+      name: notify_unsuccessful_canary_deployment
+      ref: slack.post_message
+      params:
+        message: "Something went wrong with deployment... rolling back..."
+        channel: '#bot-testing'
+    -
+      name: notify_successful_canary_deployment
+      ref: slack.post_message
+      params:
+        message: "SUCCESS!! {{project}}-{{version}} has been deployed to canary!"
+        channel: '#bot-testing'
   default: query_if_production_deploy
-

--- a/packs/cicd/actions/workflows/ac/publish_apt_package.yaml
+++ b/packs/cicd/actions/workflows/ac/publish_apt_package.yaml
@@ -1,0 +1,124 @@
+---
+  chain:
+    ### Main Workflow ###
+    -
+      name: query_build_host
+      ref: consul.query_service
+      params:
+        service: 'apt'
+      on-success: get_random_build_dir
+
+    # Build dir published as {{get_random_build_dir.localhost.stdout}}
+    -
+      name: get_random_build_dir
+      ref: core.local
+      params:
+        cmd: 'mktemp -d'
+      on-success: get_epoch_time
+
+    # Epoch published as {{get_epoch_time.localhost.stdout}}
+    -
+      name: get_epoch_time
+      ref: core.local
+      params:
+        cmd: 'date +%s'
+      on-success: download_application
+
+    -
+      name: download_application
+      ref: git.clone
+      params:
+        source: "{{url}}"
+        destination: "{{get_random_build_dir.localhost.stdout}}"
+        ref: "{{branch}}"
+        hosts: "{{query_build_host.result[0]['Address']}}"
+      on-success: get_package_metadata
+
+    # This is a really odd work-around to load data from a client-side. #
+    -
+      name: get_package_metadata
+      ref: core.remote
+      params:
+        cmd: "cat {{get_random_build_dir.localhost.stdout}}/fpm.json"
+        hosts: "{{query_build_host.result[0]['Address']}}"
+      on-success: parse_metadata
+    -
+      name: parse_metadata
+      ref: json.parse
+      params:
+        string: "{{get_package_metadata[query_build_host.result[0]['Address']].stdout}}"
+      on-success: package_application
+    # Another hack. Attempted to do this with core.remote, but it did
+    # not behave as I would have expected it to.
+    # `dir` attribute did not appear to work with relative path.
+    # no such file or directory.
+    # Turns out I didn't end up using this, warrants a discussion?
+    # -
+    #   name: bootstrap_application
+    #   ref: core.remote
+    #   params:
+    #     cmd: "script/setup"
+    #     dir: "{{get_random_build_dir.localhost.stdout}}"
+    #     hosts: "{{query_build_host.result[0]['Address']}}"
+    #   on-success: package_application
+    #
+    # Attempt with shim
+    # -
+    #   name: bootstrap_application
+    #   ref: cicd.setup
+    #   params:
+    #     path: "{{get_random_build_dir.localhost.stdout}}"
+    #     hosts: "{{query_build_host.result[0]['Address']}}"
+    #   on-success: pacakge_application
+    #-
+    #  name: package_application
+    #  ref: fpm.create_deb_from_dir
+    #  params:
+    #    name: "{{project}}"
+    #    description: "{{parse_metadata.result.description}}"
+    #    version: "{{parse_metadata.result.version}}"
+    #    revision: "{{get_epoch_time.localhost.stdout}}"
+    #    input: '.'
+    #    prefix: "/opt/{{project}}"
+    #    after_install: "{{get_random_build_dir.localhost.stdout}}/script/setup"
+    #    chdir: "{{get_random_build_dir.localhost.stdout}}"
+    #    architecture: 'all'
+    #    hosts: "{{query_build_host.result[0]['Address']}}"
+    #  on-success: parse_fpm_metadata
+    #-
+    #  name: parse_fpm_metadata
+    #  ref: json.parse
+    #  params:
+    #    string: "{{package_application[query_build_host.result[0]['Address']].stdout}}"
+    -
+      name: upload_package_to_repository
+      ref: freight.add_package
+      params:
+        file: "/tmp/{{parse_fpm_metadata.result.path}}"
+        distribution: "precise trusty wheezy jesse"
+        hosts: "{{query_build_host.result[0]['Address']}}"
+      on-success: update_repository
+
+    -
+      name: update_repository
+      ref: freight.update_cache
+      params:
+        hosts: "{{query_build_host.result[0]['Address']}}"
+
+    -
+      name: deploy_package
+      ref: core.local
+      params:
+        cmd: 'echo handoff to deploy workflow'
+      on-success: cleanup
+
+    -
+      name: cleanup
+      ref: core.remote
+      params:
+        cmd: "rm -rf {{get_random_build_dir.localhost.stdout}}"
+        hostname: "{{query_build_host.result[0]['Address']}}"
+
+    ### Notifications ###
+    ### END CHAIN ###
+  default: query_build_host

--- a/packs/cicd/actions/workflows/ac/publish_apt_package.yaml
+++ b/packs/cicd/actions/workflows/ac/publish_apt_package.yaml
@@ -23,7 +23,6 @@
       params:
         cmd: 'date +%s'
       on-success: download_application
-
     -
       name: download_application
       ref: git.clone
@@ -31,7 +30,7 @@
         source: "{{url}}"
         destination: "{{get_random_build_dir.localhost.stdout}}"
         ref: "{{branch}}"
-        hosts: "{{query_build_host.result[0]['Address']}}"
+        hosts: "{{query_build_host.result}}"
       on-success: get_package_metadata
 
     # This is a really odd work-around to load data from a client-side. #
@@ -40,13 +39,13 @@
       ref: core.remote
       params:
         cmd: "cat {{get_random_build_dir.localhost.stdout}}/fpm.json"
-        hosts: "{{query_build_host.result[0]['Address']}}"
+        hosts: "{{query_build_host.result}}"
       on-success: parse_metadata
     -
       name: parse_metadata
       ref: json.parse
       params:
-        string: "{{get_package_metadata[query_build_host.result[0]['Address']].stdout}}"
+        string: "{{get_package_metadata[query_build_host.result].stdout}}"
       on-success: package_application
     # Another hack. Attempted to do this with core.remote, but it did
     # not behave as I would have expected it to.
@@ -70,55 +69,61 @@
     #     path: "{{get_random_build_dir.localhost.stdout}}"
     #     hosts: "{{query_build_host.result[0]['Address']}}"
     #   on-success: pacakge_application
-    #-
-    #  name: package_application
-    #  ref: fpm.create_deb_from_dir
-    #  params:
-    #    name: "{{project}}"
-    #    description: "{{parse_metadata.result.description}}"
-    #    version: "{{parse_metadata.result.version}}"
-    #    revision: "{{get_epoch_time.localhost.stdout}}"
-    #    input: '.'
-    #    prefix: "/opt/{{project}}"
-    #    after_install: "{{get_random_build_dir.localhost.stdout}}/script/setup"
-    #    chdir: "{{get_random_build_dir.localhost.stdout}}"
-    #    architecture: 'all'
-    #    hosts: "{{query_build_host.result[0]['Address']}}"
-    #  on-success: parse_fpm_metadata
-    #-
-    #  name: parse_fpm_metadata
-    #  ref: json.parse
-    #  params:
-    #    string: "{{package_application[query_build_host.result[0]['Address']].stdout}}"
+
+    # Regardless what I do here, the output of this file is always at /home/stanley
+    # `dir` is ignored.
+    # Package output is: /home/stanley/{{project}}_{{parse_metadata.result.version}}-{{commit}}-{{get_epoch_time.localhost.stdout}}_all.deb
+    -
+      name: package_application
+      ref: fpm.create_deb_from_dir
+      params:
+        name: "{{project}}"
+        description: "{{parse_metadata.result.description}}"
+        version: "{{parse_metadata.result.version}}"
+        revision: "{{get_epoch_time.localhost.stdout}}-{{commit}}"
+        input: '.'
+        prefix: "/opt/{{project}}"
+        after_install: "{{get_random_build_dir.localhost.stdout}}/script/post-install"
+        chdir: "{{get_random_build_dir.localhost.stdout}}"
+        architecture: 'all'
+        hosts: "{{query_build_host.result}}"
+      on-success: upload_package_to_repository
     -
       name: upload_package_to_repository
       ref: freight.add_package
       params:
-        file: "/tmp/{{parse_fpm_metadata.result.path}}"
-        distribution: "precise trusty wheezy jesse"
-        hosts: "{{query_build_host.result[0]['Address']}}"
+        file: "/home/stanley/{{project}}_{{parse_metadata.result.version}}-{{get_epoch_time.localhost.stdout}}-{{commit}}_all.deb"
+        distribution: "trusty"
+        hosts: "{{query_build_host.result}}"
       on-success: update_repository
-
     -
       name: update_repository
       ref: freight.update_cache
       params:
-        hosts: "{{query_build_host.result[0]['Address']}}"
-
-    -
-      name: deploy_package
-      ref: core.local
-      params:
-        cmd: 'echo handoff to deploy workflow'
+        hosts: "{{query_build_host.result}}"
       on-success: cleanup
-
     -
       name: cleanup
       ref: core.remote
       params:
         cmd: "rm -rf {{get_random_build_dir.localhost.stdout}}"
-        hostname: "{{query_build_host.result[0]['Address']}}"
-
+        hosts: "{{query_build_host.result}}"
+      on-success: notify_success
+    -
+      name: notify_success
+      ref: slack.post_message
+      params:
+        message: "Successfully built {{project}}-{{parse_metadata.result.version}}-{{get_epoch_time.localhost.stdout}}-{{commit}}"
+        channel: '#bot-testing'
+      on-success: deploy_package
+    -
+      name: deploy_package
+      ref: cicd.deploy
+      params:
+        project: "{{project}}"
+        version: "{{parse_metadata.result.version}}-{{get_epoch_time.localhost.stdout}}-{{commit}}"
+        app_role: fe
     ### Notifications ###
+
     ### END CHAIN ###
   default: query_build_host

--- a/packs/cicd/actions/workflows/mistral/canary.yaml
+++ b/packs/cicd/actions/workflows/mistral/canary.yaml
@@ -1,0 +1,375 @@
+---
+name: 'cicd.canary'
+version: '2.0'
+description: Pipeline used to guide projects through a canary deployment. Accompanies Infrastructure Seed CI/CD
+workflows:
+
+#  # Entry point: Webhook Listener for cicd pipeline. Will be called prior to CI build even begins
+#  # Just experimenting here... not actually in use.
+#  validate_compatable_project:
+#    description: Subflow to perform validation on the input project to determine if eligible for running through the canary pipeline
+#    type: direct
+#    input:
+#      - project
+#      - branch
+#      - build_host
+#      - build_directory: "/tmp/{{$.project}}"
+#    task-defaults:
+#      # TODO: Expose a WARN or NOTICE type attribute return in the event a new project
+#      #       is run through this pipeline but has not been setup properly yet.
+#      on-error:
+#        - pause
+#    tasks:
+#      clone_repository:
+#        action: clone_repository
+#        description: Clone repository for processing
+#        input:
+#          project: $.project
+#          host: $.build_host
+#          directory: $.build_directory
+#        on-success:
+#          - check_required_build_scripts
+#        on-error:
+#          - notify_clone_failure
+#      notify_clone_failure:
+#        action: notify
+#        input:
+#          message: "The project {{$.project}}/{{$.branch}} failed to clone."
+#      check_required_build_scripts:
+#        # Should return true/false
+#        #
+#        # Required are:
+#        #  - script/cisetup        :: Any pre-flight checks that may need to be run prior to a cibuild
+#        #  - script/cibuild        :: Commands necessary to run a CI Build
+#        #  - script/pre-package    :: Commands necessary prior to packaging for deployment (run on the buildhost)
+#        #  - config/fpm.yml        :: All package metadata associated with package building
+#        description: Checks for the required scripts necessary to run a project through the build steps and deploy canary apps
+#        action: check_required_build_scripts
+#        input:
+#          host: $.build_host
+#          directory: $.build_directory
+#        on-error:
+#          - notify_does_not_meet_requirements
+#      notify_does_not_meet_requirements:
+#        action: notify
+#        input:
+#          message: "The project {{$.project}}/{{$.branch}} is not configured to use this pipeline. Please see XXX for more details"
+
+  # Factory to build out an APT package from a repository
+  #   Downloads repository, runs pre-package scripts, and bundles it all up.
+  #   TODO: Calculate a build host based on utilization?
+  #
+  #   Based on input, should
+  publish_apt_package:
+    description: Subflow to package up a project and make available for distribution via APT
+    type: direct
+    input:
+      - project
+      - branch
+      - commit
+      - url
+    output:
+      # TODO Where does responsibility for the final output of a master workflow lie?
+      - project_version
+    task-defaults:
+      # TODO: Expose a WARN or NOTICE type attribute return in the event a new project
+      #       is run through this pipeline but has not been setup properly yet.
+      on-error:
+        - cleanup
+        - pause
+    tasks:
+      query_build_host:
+        action: consul_get_host
+        description: Find an available build host to be used in this pipeline
+        input:
+          service: apt
+        publish:
+          build_host: $.host
+        on-success:
+          - download
+          - get_epoch_time
+      get_epoch_time:
+        action: get_epoch_time
+        description: Get the current epoch runtime for use in build
+        publish:
+          epoch: $.epoch
+      download:
+        action: git_clone
+        description: Download the application for packaging up
+        input:
+          hostname: $.build_host
+          directory: $.build_directory
+          url: $.url
+          branch: $.branch
+          commit: $.commit
+        on-success:
+          - load_package_metadata
+      get_package_metadata:
+        action: fpm_get_metadata
+        description: Load up metadata for a project to be used during package building.
+        input:
+          hostname: $.build_host
+          directory: $.build_directory
+        publish:
+          # TODO Simplify output variables in canary/pipeline / metadata
+          # there a way to avoid having to declare each option? Maybe something like $?
+          # metadata: $.localhost.stdout  ## If this were json, would it parse?
+          package_maintainer: $.maintainer
+          package_description: $.description
+          package_after_install: $.after_install
+          package_name: $.name
+          package_license: $.license
+          package_version: $.version
+        on-success:
+          - bootstrap
+      bootstrap:
+        action: run_pre_package_tasks
+        description: Run any pre-flight checks (script/pre-package) for the project
+        input:
+          hostname: $.build_host
+          directory: $.build_directory
+        on-success:
+          - package
+      package:
+        action: fpm_package
+        input:
+          name: $.name
+          license: $.license
+          maintainer: $.package_maintainer
+          description: $.description
+          after_install: $.after_install
+          hostname: $.build_host
+          directory: $.build_directory
+          version: $.version
+          revision: "{{$.epoch}}_${{.commit}}"
+        publish:
+          package_location: $.file
+          package_version: "{{$.version}}-{{$.epoch}}_{{$.commit}}" # For command line runs not returning json, where does a value like this come from? Does it require the user to have deep knowledge of the calling action?
+        on-success:
+          - upload
+      upload:
+        action: freight_add_package
+        description: Make the project available for download/distribution.
+        input:
+          hostname: $.build_host
+          file: $.package_location
+        on-success:
+          - deploy
+          - cleanup
+      cleanup:
+        action: cleanup_apt_package
+        description: Cleanup all build artifacts from build server.
+      deploy:
+        workflow: deploy
+        input:
+          project: $.project
+          version: $.package_version
+          production: false
+  ###
+  ### Deployment
+  ###
+  deploy:
+    type: direct
+    input:
+      - project
+      - version
+      - production
+    task-defaults:
+      on-error:
+        - pause # If I need to unset this, could I? For instance, hard failure vs pause
+    tasks:
+      # Not sure about this...
+      query_if_production:
+        description: Determine if the updated value should be to the canary, or production nodes
+        action: query_if_production
+        input: 
+          production: $.production
+        on-success:
+          - get_production_version
+        on-error:
+          - get_canary_version
+      get_production_version:
+        action: consul_get_key
+        description: Query the current production version advertized for deployment and hold for reference
+        input:
+          key: "{{$.project}}::production_version"
+        publish:
+          original_production_version: $.value
+        on-success:
+          - update_production_version
+          - get_production_hosts
+      get_canary_version:
+        action: consul_get_key
+        description: Query the current canary version advertized for deployment and hold for reference
+        input:
+          key: "{{$.project}}::canary_version"
+        publish:
+          original_canary_version: $.value
+        on-success:
+          - get_canary_hosts
+          - update_canary_version
+      get_canary_hosts:
+        action: consul_get_hosts
+        description: Query the CMDB and find all the hosts that are eligible for canary deploys
+        input:
+          key: "canary_fe.{{$.project}}"
+        publish:
+          hosts: $.hosts
+      get_production_hosts:
+        action: consul_get_hosts
+        description: Query the CMDB and find all the hosts that are eligible for production deploys
+        input:
+          key: "fe.{{$.project}}"
+        publish:
+          hosts: $.hosts
+      update_production_version:
+        action: consul_put_key
+        description: Change the version of the application advertised for production deploys
+        input:
+          key: "{{$.project}}::production_version"
+          value: $.version
+        on-success:
+          - run_puppet_on_hosts
+        on-error:
+          - reset_production_version
+      update_canary_version:
+        action: consul_put_key
+        input:
+          key: "{{$.project}}::canary_version"
+          value: $.version
+        on-success:
+          - run_puppet_on_hosts
+        on-error:
+          - reset_canary_version
+      run_puppet_on_hosts:
+        action: run_puppet
+        description: Run Puppet across eligible hosts to install/update currently deployed systems
+        input:
+          hosts: $.hosts
+        on-error:
+          - reset_canary_version
+      reset_canary_version:
+        action: consul_put_key
+        description: Failsafe action to reset the advertised canary version to its original value
+        input:
+          key: "{{$.project}}::canary_version"
+          value: $.original_canary_version
+      reset_production_version:
+        action: consul_put_key
+        description: Failsafe action to reset the advertized production version to its original value
+        input:
+          key: "{{$.project}}::production_version"
+          value: $.original_production_version
+###
+### Actions
+###
+actions:
+  consul_get_key:
+    description: Query Consul for a K/V pair
+    base: std.echo
+    base-input:
+      output: "Querying consul for {{$.key}}..."
+    output:
+      value: test-123
+  ### I am not a fan of the singular vs plural here. Would love input
+  consul_get_hosts:
+    description: Query consul for all servers with a given service tag.
+    base: std.echo
+    base-input:
+      output: "Querying consul for hosts matching {{$.service}} tag..."
+    input:
+      - service
+    output:
+      hosts:
+        - test_1
+        - test_2
+  consul_get_host:
+    description: Query consul for a single server with a given service tag.
+    base: std.echo
+    base-input:
+      output: "Querying consul a host matching {{$.service}} tag..."
+    input:
+      - service
+    output:
+      host: test 3
+  get_epoch_time:
+    description: Retrieve current epoch time
+    base: std.echo
+    base-input:
+      output: "Attempting to get current epoch time..."
+    output:
+      epoch: '999999999'
+  git_clone:
+    description: Clone git repository locally.
+    base: std.echo
+    base-input:
+      output: "Attempting to download {{$.url}}/{{$.branch}}..."
+    input:
+      - hostname
+      - build_directory
+      - url
+      - branch
+      - commit
+  fpm_get_metadata:
+    description: Load package metadata directly from the project itself.
+    base: std.echo
+    base-input:
+      output: "Attempting to load metadata from {{$.hostname}}:{{$.directory}} ..."
+    input:
+      - hostname
+      - directory
+    output:
+      metadata: Test Metadata
+      maintainer: Test Maintainer
+      description: Test Description
+      after_install: script/setup
+      name: test
+      license: Test License
+  run_pre_package_tasks:
+    description: Load up any pre-run scripts necessary prior to packaging up.
+    base: std.echo
+    base-input:
+      output: "Attempting to run pre-package tasks at {{$.hostname}}:{{$.directory}} ..."
+    input:
+      - hostname
+      - directory
+  fpm_package:
+    description: Package up a directory with fpm.
+    base: std.echo
+    base-input:
+      output: "Attempting to package repository with fpm at {{$.hostname}}:{{$.directory}} ..."
+    input:
+      - hostname
+      - directory
+      - name
+      - license
+      - maintainer
+      - description
+      - after_install
+      - version
+      - revision
+    output:
+      file: /tmp/testpackage.deb
+  freight_add_package:
+    description: Add package to freight cache.
+    base: std.echo
+    base-input:
+      output: "Adding {{$.file}} to freight cache..."
+    input:
+      - hostname
+      - file
+  cleanup_apt_package:
+    description: A step to clean up all remaining bits
+    base: std.echo
+    base-input:
+      output: "Removing all build artifacts..."
+  query_if_production:
+    description: Determine if the workflow should run production deployments
+    base: std.echo
+    base-input:
+      output: "Checking this workflow is deploying to production"
+  run_puppet:
+    description: Run puppet on the specified hosts...
+    base: std.echo
+    base-input:
+      output: "Running production on {{$.hosts}}"

--- a/packs/cicd/actions/workflows/mistral/canary_test_data.json
+++ b/packs/cicd/actions/workflows/mistral/canary_test_data.json
@@ -1,0 +1,6 @@
+{
+  "project": "seatshare-rails",
+  "branch": "testbranch",
+  "commit": "deadbeef",
+  "url": "https://github.com/jfryman/seatshare-rails.git"
+}

--- a/packs/cicd/config.yaml
+++ b/packs/cicd/config.yaml
@@ -1,0 +1,3 @@
+### Place configuration data for your pack here.
+---
+

--- a/packs/cicd/pack.yaml
+++ b/packs/cicd/pack.yaml
@@ -1,0 +1,8 @@
+### Place information about your pack version here.
+---
+name: cicd
+description: Continuous Delivery / Continous Integration pipeline. Accompanies CI/CD Infrastructure seed
+version: 0.0.1
+author: James Fryman
+email: james@fryman.io
+

--- a/packs/cicd/rules/README.md
+++ b/packs/cicd/rules/README.md
@@ -1,0 +1,3 @@
+# rules
+
+The rules folder contains rules. See [Rules](http://docs.stackstorm.com/rules.html) for specifics on writing rules.

--- a/packs/cicd/rules/chatops_publish_apt_package.yaml
+++ b/packs/cicd/rules/chatops_publish_apt_package.yaml
@@ -1,0 +1,17 @@
+---
+  name: chatops.publish_apt_package
+  description: "Execute `cicd.publish_apt_package` directly from Slack"
+  enabled: false
+  trigger:
+    type: slack.message
+    pack: slack
+  criteria:
+    trigger.channel.name:
+      type: equals
+      pattern: '#bot-testing'
+  action:
+    ref: slack.post_message
+    parameters:
+      message: "{{trigger.user.name}} said {{trigger.text}}"
+      channel: '#bot-testing'
+

--- a/packs/cicd/rules/github_push_event.yaml
+++ b/packs/cicd/rules/github_push_event.yaml
@@ -1,0 +1,21 @@
+---
+    name: 'st2.webhook.cicd.events'
+    description: 'Webhook listening for pushes to our CI/CD (SeatShare) repository'
+    trigger:
+        type: core.st2.webhook
+        parameters:
+            url: cicd/events
+#    TODO Problem with X-GitHub-Event header in rule
+#    Cannot seem to work as header or headers. Based on code, it looks like headers
+#    actually do not go anywhere.
+#    https://github.com/StackStorm/st2/blob/d6fab54e189c32e93843805ff17c8f8e86732939/st2api/st2api/controllers/v1/webhooks.py#L84
+#    criteria:
+#      "trigger.headers.X-GitHub-Event":
+#          pattern: "push"
+#          type: "eq"
+    action:
+        ref: jenkins.build_job
+        parameters:
+            project: "{{trigger.body.repository.name}}"
+            branch: "{{trigger.body.ref}}"
+    enabled: true

--- a/packs/cicd/rules/jenkins_job_failure.yaml
+++ b/packs/cicd/rules/jenkins_job_failure.yaml
@@ -1,0 +1,24 @@
+---
+    # TODO Document Jenkins Job Status for CI/CD workflow
+    name: 'st2.webhook.cicd.jenkins.job_failure'
+    enabled: true
+    description: 'Webhook listening for responses from Jenkins'
+    trigger:
+        type: core.st2.webhook
+        parameters:
+            url: cicd/jenkins
+    criteria:
+      trigger.body.phase:
+        pattern: "FINALIZED"
+        type: equals
+      trigger.body.build.status:
+        pattern: "FAILURE"
+        type: equals
+
+    # TODO Make Jenkins Start Build go to ChatOps somewhere. Workflow?
+    # This should go to a more complex workflow then? Where do I splay out from here?
+    action:
+      ref: core.local
+      parameters:
+        cmd: "echo 'Build for {{trigger.body.name}}/{{trigger.body.scm.branch}} failed!. Details at {{trigger.body.build.full_url}}' >> /tmp/st2.jenkins.cicd.out"
+

--- a/packs/cicd/rules/jenkins_job_failure.yaml
+++ b/packs/cicd/rules/jenkins_job_failure.yaml
@@ -18,7 +18,8 @@
     # TODO Make Jenkins Start Build go to ChatOps somewhere. Workflow?
     # This should go to a more complex workflow then? Where do I splay out from here?
     action:
-      ref: core.local
+      ref: slack.post_message
       parameters:
-        cmd: "echo 'Build for {{trigger.body.name}}/{{trigger.body.scm.branch}} failed!. Details at {{trigger.body.build.full_url}}' >> /tmp/st2.jenkins.cicd.out"
+        message: "Build for {{trigger.body.name}}/{{trigger.body.scm.branch}} failed!. Details at {{trigger.body.build.full_url}}"
+        channel: "#bot-testing"
 

--- a/packs/cicd/rules/jenkins_job_start.yaml
+++ b/packs/cicd/rules/jenkins_job_start.yaml
@@ -1,0 +1,18 @@
+---
+    # TODO Document Jenkins Job Status for CI/CD workflow
+    name: 'st2.webhook.cicd.jenkins.job_start'
+    enabled: true
+    description: 'Webhook listening for responses from Jenkins'
+    trigger:
+        type: core.st2.webhook
+        parameters:
+            url: cicd/jenkins
+    criteria:
+      trigger.body.phase:
+        pattern: "STARTED"
+        type: equals
+    # TODO Make Jenkins Start Build go to ChatOps somewhere. Workflow?
+    action:
+      ref: core.local
+      parameters:
+        cmd: "echo 'Build for {{trigger.body.name}}/{{trigger.body.scm.branch}} started. Details at {{trigger.body.build.full_url}}' >> /tmp/st2.jenkins.cicd.out"

--- a/packs/cicd/rules/jenkins_job_start.yaml
+++ b/packs/cicd/rules/jenkins_job_start.yaml
@@ -13,6 +13,7 @@
         type: equals
     # TODO Make Jenkins Start Build go to ChatOps somewhere. Workflow?
     action:
-      ref: core.local
+      ref: slack.post_message
       parameters:
-        cmd: "echo 'Build for {{trigger.body.name}}/{{trigger.body.scm.branch}} started. Details at {{trigger.body.build.full_url}}' >> /tmp/st2.jenkins.cicd.out"
+        message: "Build for {{trigger.body.name}}/{{trigger.body.scm.branch}} started. Details at {{trigger.body.build.full_url}}"
+        channel: '#bot-testing'

--- a/packs/cicd/rules/jenkins_job_success_to_package.yaml
+++ b/packs/cicd/rules/jenkins_job_success_to_package.yaml
@@ -15,7 +15,7 @@
         pattern: "SUCCESS"
         type: equals
     action:
-      ref: cicd.canary.publish_apt_package
+      ref: cicd.publish_apt_package
       parameters:
         project:  "{{trigger.body.name}}"
         url: "{{trigger.body.scm.url}}"

--- a/packs/cicd/rules/jenkins_job_success_to_package.yaml
+++ b/packs/cicd/rules/jenkins_job_success_to_package.yaml
@@ -1,0 +1,24 @@
+---
+    # TODO Document Jenkins Job Status for CI/CD workflow
+    name: 'st2.webhook.cicd.jenkins.job_success_to_package'
+    enabled: true
+    description: 'Webhook listening for responses from Jenkins'
+    trigger:
+        type: core.st2.webhook
+        parameters:
+            url: cicd/jenkins
+    criteria:
+      trigger.body.phase:
+        pattern: "FINALIZED"
+        type: equals
+      trigger.body.build.status:
+        pattern: "SUCCESS"
+        type: equals
+    action:
+      ref: cicd.canary.publish_apt_package
+      parameters:
+        project:  "{{trigger.body.name}}"
+        url: "{{trigger.body.scm.url}}"
+        branch: "{{trigger.body.scm.branch}}"
+        commit: "{{trigger.body.scm.commit}}"
+

--- a/packs/cicd/sensors/README.md
+++ b/packs/cicd/sensors/README.md
@@ -1,0 +1,4 @@
+# sensors
+
+The sensors folder contains sensoros. See [Sensors](http://docs.stackstorm.com/sensors.html) for specifics on writing
+sensors and registering TriggerTypes.

--- a/packs/consul/actions/parse_nodes.py
+++ b/packs/consul/actions/parse_nodes.py
@@ -1,0 +1,7 @@
+from lib import action
+
+class ConsulParseNodesAction(action.ConsulBaseAction):
+    def run(self, data):
+        nodes = []
+        # Loop through the keys, and return the needful
+        return nodes

--- a/packs/consul/actions/parse_nodes.yaml
+++ b/packs/consul/actions/parse_nodes.yaml
@@ -1,0 +1,10 @@
+name: parse_nodes
+runner_type: run-python
+description: "Helper function to extract hosts from a consul response to be used with StackStorm workflows"
+enabled: true
+entry_point: "parse_nodes"
+parameters:
+  data:
+    type: string
+    description: Data from consul query
+    required: true

--- a/packs/consul/actions/query_service.py
+++ b/packs/consul/actions/query_service.py
@@ -1,6 +1,7 @@
 from lib import action
 
 class ConsulQueryServiceAction(action.ConsulBaseAction):
-    def run(self, service):
-        index, service = self.consul.catalog.service(service)
-        return service
+    def run(self, service, tag=None):
+        index, service = self.consul.catalog.service(service, tag=tag)
+        addresses = [node['Address'] for node in service]
+        return ','.join(addresses)

--- a/packs/consul/actions/query_service.yaml
+++ b/packs/consul/actions/query_service.yaml
@@ -9,3 +9,7 @@ parameters:
         description: "Service to query in Consul"
         required: true
         position: 0
+    tag:
+        type: string
+        description: "Optional tags to query"
+        position: 1

--- a/packs/debian/actions/README.md
+++ b/packs/debian/actions/README.md
@@ -1,0 +1,5 @@
+# actions
+
+The actions folder contains action scripts and metadata files. See [Actions](http://docs.stackstorm.com/actions.html)
+and [Workflows](http://docs.stackstorm.com/workflows.html) for specifics on writing actions. Note that the lib sub-folder
+is always available for access for an action script.

--- a/packs/debian/actions/apt-get-install.sh
+++ b/packs/debian/actions/apt-get-install.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+PACKAGE=$1
+VERSION=""
+
+if [ -z "$2" ]; then
+  VERSION="=${2}"
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+sudo apt-get install ${PACKAGE}${VERSION}

--- a/packs/debian/actions/apt-get-update.sh
+++ b/packs/debian/actions/apt-get-update.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+sudo apt-get update

--- a/packs/debian/actions/apt_get_install.yaml
+++ b/packs/debian/actions/apt_get_install.yaml
@@ -1,0 +1,17 @@
+---
+name: apt_get_install
+description: Install a package from APT
+runner_type: run-remote
+enabled: true
+entry_point: 'apt-get-install.sh'
+parameters:
+  package:
+    type: string
+    description: Name of the package to be installed
+    required: true
+    position: 1
+  version:
+    type: string
+    description: Version of the package to be installed
+    position: 2
+

--- a/packs/debian/actions/apt_get_update.yaml
+++ b/packs/debian/actions/apt_get_update.yaml
@@ -1,0 +1,6 @@
+---
+name: apt_get_update
+description: Update the APT cache
+runner_type: run-remote
+entry_point: 'apt-get-update.sh'
+enabled: true

--- a/packs/debian/actions/apt_get_update_install.yaml
+++ b/packs/debian/actions/apt_get_update_install.yaml
@@ -1,0 +1,21 @@
+---
+name: apt_get_update_install
+runner_type: action-chain
+description: Update APT cache and install a package
+enabled: true
+entry_point: workflows/ac/apt_get_update_install.yaml
+parameters:
+  package:
+    type: string
+    description: Name of the package to be installed
+    required: true
+    position: 1
+  version:
+    type: string
+    description: Version of the package to be installed
+    position: 2
+  hosts:
+    type: string
+    description: Remote hosts to execute this command on
+    position: 3
+

--- a/packs/debian/actions/workflows/ac/apt_get_update_install.yaml
+++ b/packs/debian/actions/workflows/ac/apt_get_update_install.yaml
@@ -1,0 +1,16 @@
+---
+  chain:
+    -
+      name: apt_get_update
+      ref: debian.apt_get_update
+      params:
+        hosts: "{{hosts}}"
+      on-success: apt_get_install
+    -
+      name: apt_get_install
+      ref: debian.apt_get_install
+      params:
+        package: "{{package}}"
+        version: "{{version}}"
+        hosts: "{{hosts}}"
+  default: apt_get_update

--- a/packs/debian/config.yaml
+++ b/packs/debian/config.yaml
@@ -1,0 +1,3 @@
+### Place configuration data for your pack here.
+---
+

--- a/packs/debian/pack.yaml
+++ b/packs/debian/pack.yaml
@@ -1,0 +1,8 @@
+### Place information about your pack version here.
+---
+name: debian
+description: Actions specific to the Debian/Ubuntu family of OSes
+version: 0.0.1
+author: James Fryman
+email: james@fryman.io
+

--- a/packs/debian/rules/README.md
+++ b/packs/debian/rules/README.md
@@ -1,0 +1,3 @@
+# rules
+
+The rules folder contains rules. See [Rules](http://docs.stackstorm.com/rules.html) for specifics on writing rules.

--- a/packs/debian/sensors/README.md
+++ b/packs/debian/sensors/README.md
@@ -1,0 +1,4 @@
+# sensors
+
+The sensors folder contains sensoros. See [Sensors](http://docs.stackstorm.com/sensors.html) for specifics on writing
+sensors and registering TriggerTypes.

--- a/packs/fpm/actions/autogen.rb
+++ b/packs/fpm/actions/autogen.rb
@@ -18,49 +18,67 @@ DEFAULT_PARAMETERS = {
     'description' => 'Package Name (e.g.: libpq)',
     'required' => true,
   },
+  'description' => {
+    'type' => 'string',
+    'description' => 'Package Description (e.g.: Provides PostgreSQL Client libs)',
+    'default' => 'Autobuilt package {{name}} by StackStorm + FPM Integration',
+  },
   'source' => {
     'type' => 'string',
     'description' => 'Source type for fpm',
   },
-  'output' => {
-    'type' => 'string',
-    'description' => 'Package output type for fpm',
-  },
   'version' => {
     'type' => 'string',
-    'description' => 'Package Versioni (e.g.: 0.1.1)',
+    'description' => 'Package Version (e.g.: 0.1.1)',
     'required' => true,
   },
   'revision' => {
     'type' => 'string',
     'description' => 'Package Revision (e.g: 2)',
     'default' => '1',
+  },
+  'input' => {
+    'type' => 'string',
+    'description' => "Inputs to the source package type. For the 'dir' type, this is the files and directories you want to include in the package. For others, like 'gem', it specifies the packages to download and use as the gem input",
     'required' => true,
   },
-  'cmd' => {
-    'default' => 'fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration {{revision}}',
-    'immutable' => true,
-  },
-}
-
-### These need to be re-added once https://github.com/StackStorm/st2/issues/887
-### is resolved
-OPTIONAL = {
-  'description' => {
+  'output' => {
     'type' => 'string',
-    'description' => 'Package Description (e.g.: Provides PostgreSQL Client libs)',
+    'description' => 'Package output type for fpm',
   },
-  'maintainer' => {
+  'output_file' => {
     'type' => 'string',
-    'description' => 'The maintainer of this package. (default: "<root@product-flashflirt.stage.office.airg.lan>")',
-  },
-  'c' => {
-    'type' => 'string',
-    'description' => '(chroot) Change directory to here before searching for files',
+    'description' => 'The package file path to output.',
+    'required' => 'true',
   },
   'prefix' => {
     'type' => 'string',
-    'description' => "A path to prefix files with when building the target package. This may be necessary for all input packages. For example, the 'gem' type will prefix with your gem directory automatically.",
+    'description' => 'A path to prefix files with when building the target package.',
+    'default' => "/opt/{{name}}"
+  },
+  'after_install' => {
+    'type' => 'string',
+    'description' => 'A script to be run after package removal',
+    'default' => '/bin/true',
+  },
+  'chdir' => {
+    'type' => 'string',
+    'description' => 'Change directory to here before searching for files',
+    'default' => '{{dir}}',
+  },
+  'architecture' => {
+    'type' => 'string',
+    'description' => 'The architecture name. (usually matches `uname -a`). Use `all` for noarch',
+    'default' => 'x86_64',
+  },
+  'maintainer' => {
+    'type' => 'string',
+    'description' => 'Maintainer of this package',
+    'default' => 'root@product-flashflirt.stage.office.airg.lan',
+  },
+  'cmd' => {
+    'default' => 'fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}} --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}} -p {{output_file}} {{input}}',
+    'immutable' => true,
   },
 }
 

--- a/packs/fpm/actions/autogen.rb
+++ b/packs/fpm/actions/autogen.rb
@@ -46,11 +46,6 @@ DEFAULT_PARAMETERS = {
     'type' => 'string',
     'description' => 'Package output type for fpm',
   },
-  'output_file' => {
-    'type' => 'string',
-    'description' => 'The package file path to output.',
-    'required' => 'true',
-  },
   'prefix' => {
     'type' => 'string',
     'description' => 'A path to prefix files with when building the target package.',
@@ -77,7 +72,7 @@ DEFAULT_PARAMETERS = {
     'default' => 'root@product-flashflirt.stage.office.airg.lan',
   },
   'cmd' => {
-    'default' => 'fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}} --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}} -p {{output_file}} {{input}}',
+    'default' => 'fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}} --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}} {{input}}',
     'immutable' => true,
   },
 }

--- a/packs/fpm/actions/create_deb_from_deb.yaml
+++ b/packs/fpm/actions/create_deb_from_deb.yaml
@@ -35,10 +35,6 @@ parameters:
     type: string
     description: Package output type for fpm
     default: deb
-  output_file:
-    type: string
-    description: The package file path to output.
-    required: 'true'
   prefix:
     type: string
     description: A path to prefix files with when building the target package.
@@ -64,5 +60,5 @@ parameters:
     default: fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration
       {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}}
       --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}}
-      -p {{output_file}} {{input}}
+      {{input}}
     immutable: true

--- a/packs/fpm/actions/create_deb_from_deb.yaml
+++ b/packs/fpm/actions/create_deb_from_deb.yaml
@@ -9,24 +9,60 @@ parameters:
     type: string
     description: 'Package Name (e.g.: libpq)'
     required: true
+  description:
+    type: string
+    description: 'Package Description (e.g.: Provides PostgreSQL Client libs)'
+    default: Autobuilt package {{name}} by StackStorm + FPM Integration
   source:
     type: string
     description: Source type for fpm
     default: deb
-  output:
-    type: string
-    description: Package output type for fpm
-    default: deb
   version:
     type: string
-    description: 'Package Versioni (e.g.: 0.1.1)'
+    description: 'Package Version (e.g.: 0.1.1)'
     required: true
   revision:
     type: string
     description: 'Package Revision (e.g: 2)'
     default: '1'
+  input:
+    type: string
+    description: Inputs to the source package type. For the 'dir' type, this is the
+      files and directories you want to include in the package. For others, like 'gem',
+      it specifies the packages to download and use as the gem input
     required: true
+  output:
+    type: string
+    description: Package output type for fpm
+    default: deb
+  output_file:
+    type: string
+    description: The package file path to output.
+    required: 'true'
+  prefix:
+    type: string
+    description: A path to prefix files with when building the target package.
+    default: /opt/{{name}}
+  after_install:
+    type: string
+    description: A script to be run after package removal
+    default: /bin/true
+  chdir:
+    type: string
+    description: Change directory to here before searching for files
+    default: '{{dir}}'
+  architecture:
+    type: string
+    description: The architecture name. (usually matches `uname -a`). Use `all` for
+      noarch
+    default: x86_64
+  maintainer:
+    type: string
+    description: Maintainer of this package
+    default: root@product-flashflirt.stage.office.airg.lan
   cmd:
     default: fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration
-      {{revision}}
+      {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}}
+      --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}}
+      -p {{output_file}} {{input}}
     immutable: true

--- a/packs/fpm/actions/create_deb_from_dir.yaml
+++ b/packs/fpm/actions/create_deb_from_dir.yaml
@@ -35,10 +35,6 @@ parameters:
     type: string
     description: Package output type for fpm
     default: deb
-  output_file:
-    type: string
-    description: The package file path to output.
-    required: 'true'
   prefix:
     type: string
     description: A path to prefix files with when building the target package.
@@ -64,5 +60,5 @@ parameters:
     default: fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration
       {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}}
       --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}}
-      -p {{output_file}} {{input}}
+      {{input}}
     immutable: true

--- a/packs/fpm/actions/create_deb_from_dir.yaml
+++ b/packs/fpm/actions/create_deb_from_dir.yaml
@@ -9,24 +9,60 @@ parameters:
     type: string
     description: 'Package Name (e.g.: libpq)'
     required: true
+  description:
+    type: string
+    description: 'Package Description (e.g.: Provides PostgreSQL Client libs)'
+    default: Autobuilt package {{name}} by StackStorm + FPM Integration
   source:
     type: string
     description: Source type for fpm
     default: dir
-  output:
-    type: string
-    description: Package output type for fpm
-    default: deb
   version:
     type: string
-    description: 'Package Versioni (e.g.: 0.1.1)'
+    description: 'Package Version (e.g.: 0.1.1)'
     required: true
   revision:
     type: string
     description: 'Package Revision (e.g: 2)'
     default: '1'
+  input:
+    type: string
+    description: Inputs to the source package type. For the 'dir' type, this is the
+      files and directories you want to include in the package. For others, like 'gem',
+      it specifies the packages to download and use as the gem input
     required: true
+  output:
+    type: string
+    description: Package output type for fpm
+    default: deb
+  output_file:
+    type: string
+    description: The package file path to output.
+    required: 'true'
+  prefix:
+    type: string
+    description: A path to prefix files with when building the target package.
+    default: /opt/{{name}}
+  after_install:
+    type: string
+    description: A script to be run after package removal
+    default: /bin/true
+  chdir:
+    type: string
+    description: Change directory to here before searching for files
+    default: '{{dir}}'
+  architecture:
+    type: string
+    description: The architecture name. (usually matches `uname -a`). Use `all` for
+      noarch
+    default: x86_64
+  maintainer:
+    type: string
+    description: Maintainer of this package
+    default: root@product-flashflirt.stage.office.airg.lan
   cmd:
     default: fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration
-      {{revision}}
+      {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}}
+      --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}}
+      -p {{output_file}} {{input}}
     immutable: true

--- a/packs/fpm/actions/create_deb_from_empty.yaml
+++ b/packs/fpm/actions/create_deb_from_empty.yaml
@@ -35,10 +35,6 @@ parameters:
     type: string
     description: Package output type for fpm
     default: deb
-  output_file:
-    type: string
-    description: The package file path to output.
-    required: 'true'
   prefix:
     type: string
     description: A path to prefix files with when building the target package.
@@ -64,5 +60,5 @@ parameters:
     default: fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration
       {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}}
       --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}}
-      -p {{output_file}} {{input}}
+      {{input}}
     immutable: true

--- a/packs/fpm/actions/create_deb_from_empty.yaml
+++ b/packs/fpm/actions/create_deb_from_empty.yaml
@@ -9,24 +9,60 @@ parameters:
     type: string
     description: 'Package Name (e.g.: libpq)'
     required: true
+  description:
+    type: string
+    description: 'Package Description (e.g.: Provides PostgreSQL Client libs)'
+    default: Autobuilt package {{name}} by StackStorm + FPM Integration
   source:
     type: string
     description: Source type for fpm
     default: empty
-  output:
-    type: string
-    description: Package output type for fpm
-    default: deb
   version:
     type: string
-    description: 'Package Versioni (e.g.: 0.1.1)'
+    description: 'Package Version (e.g.: 0.1.1)'
     required: true
   revision:
     type: string
     description: 'Package Revision (e.g: 2)'
     default: '1'
+  input:
+    type: string
+    description: Inputs to the source package type. For the 'dir' type, this is the
+      files and directories you want to include in the package. For others, like 'gem',
+      it specifies the packages to download and use as the gem input
     required: true
+  output:
+    type: string
+    description: Package output type for fpm
+    default: deb
+  output_file:
+    type: string
+    description: The package file path to output.
+    required: 'true'
+  prefix:
+    type: string
+    description: A path to prefix files with when building the target package.
+    default: /opt/{{name}}
+  after_install:
+    type: string
+    description: A script to be run after package removal
+    default: /bin/true
+  chdir:
+    type: string
+    description: Change directory to here before searching for files
+    default: '{{dir}}'
+  architecture:
+    type: string
+    description: The architecture name. (usually matches `uname -a`). Use `all` for
+      noarch
+    default: x86_64
+  maintainer:
+    type: string
+    description: Maintainer of this package
+    default: root@product-flashflirt.stage.office.airg.lan
   cmd:
     default: fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration
-      {{revision}}
+      {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}}
+      --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}}
+      -p {{output_file}} {{input}}
     immutable: true

--- a/packs/fpm/actions/create_deb_from_gem.yaml
+++ b/packs/fpm/actions/create_deb_from_gem.yaml
@@ -35,10 +35,6 @@ parameters:
     type: string
     description: Package output type for fpm
     default: deb
-  output_file:
-    type: string
-    description: The package file path to output.
-    required: 'true'
   prefix:
     type: string
     description: A path to prefix files with when building the target package.
@@ -64,5 +60,5 @@ parameters:
     default: fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration
       {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}}
       --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}}
-      -p {{output_file}} {{input}}
+      {{input}}
     immutable: true

--- a/packs/fpm/actions/create_deb_from_gem.yaml
+++ b/packs/fpm/actions/create_deb_from_gem.yaml
@@ -9,24 +9,60 @@ parameters:
     type: string
     description: 'Package Name (e.g.: libpq)'
     required: true
+  description:
+    type: string
+    description: 'Package Description (e.g.: Provides PostgreSQL Client libs)'
+    default: Autobuilt package {{name}} by StackStorm + FPM Integration
   source:
     type: string
     description: Source type for fpm
     default: gem
-  output:
-    type: string
-    description: Package output type for fpm
-    default: deb
   version:
     type: string
-    description: 'Package Versioni (e.g.: 0.1.1)'
+    description: 'Package Version (e.g.: 0.1.1)'
     required: true
   revision:
     type: string
     description: 'Package Revision (e.g: 2)'
     default: '1'
+  input:
+    type: string
+    description: Inputs to the source package type. For the 'dir' type, this is the
+      files and directories you want to include in the package. For others, like 'gem',
+      it specifies the packages to download and use as the gem input
     required: true
+  output:
+    type: string
+    description: Package output type for fpm
+    default: deb
+  output_file:
+    type: string
+    description: The package file path to output.
+    required: 'true'
+  prefix:
+    type: string
+    description: A path to prefix files with when building the target package.
+    default: /opt/{{name}}
+  after_install:
+    type: string
+    description: A script to be run after package removal
+    default: /bin/true
+  chdir:
+    type: string
+    description: Change directory to here before searching for files
+    default: '{{dir}}'
+  architecture:
+    type: string
+    description: The architecture name. (usually matches `uname -a`). Use `all` for
+      noarch
+    default: x86_64
+  maintainer:
+    type: string
+    description: Maintainer of this package
+    default: root@product-flashflirt.stage.office.airg.lan
   cmd:
     default: fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration
-      {{revision}}
+      {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}}
+      --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}}
+      -p {{output_file}} {{input}}
     immutable: true

--- a/packs/fpm/actions/create_deb_from_python.yaml
+++ b/packs/fpm/actions/create_deb_from_python.yaml
@@ -35,10 +35,6 @@ parameters:
     type: string
     description: Package output type for fpm
     default: deb
-  output_file:
-    type: string
-    description: The package file path to output.
-    required: 'true'
   prefix:
     type: string
     description: A path to prefix files with when building the target package.
@@ -64,5 +60,5 @@ parameters:
     default: fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration
       {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}}
       --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}}
-      -p {{output_file}} {{input}}
+      {{input}}
     immutable: true

--- a/packs/fpm/actions/create_deb_from_python.yaml
+++ b/packs/fpm/actions/create_deb_from_python.yaml
@@ -9,24 +9,60 @@ parameters:
     type: string
     description: 'Package Name (e.g.: libpq)'
     required: true
+  description:
+    type: string
+    description: 'Package Description (e.g.: Provides PostgreSQL Client libs)'
+    default: Autobuilt package {{name}} by StackStorm + FPM Integration
   source:
     type: string
     description: Source type for fpm
     default: python
-  output:
-    type: string
-    description: Package output type for fpm
-    default: deb
   version:
     type: string
-    description: 'Package Versioni (e.g.: 0.1.1)'
+    description: 'Package Version (e.g.: 0.1.1)'
     required: true
   revision:
     type: string
     description: 'Package Revision (e.g: 2)'
     default: '1'
+  input:
+    type: string
+    description: Inputs to the source package type. For the 'dir' type, this is the
+      files and directories you want to include in the package. For others, like 'gem',
+      it specifies the packages to download and use as the gem input
     required: true
+  output:
+    type: string
+    description: Package output type for fpm
+    default: deb
+  output_file:
+    type: string
+    description: The package file path to output.
+    required: 'true'
+  prefix:
+    type: string
+    description: A path to prefix files with when building the target package.
+    default: /opt/{{name}}
+  after_install:
+    type: string
+    description: A script to be run after package removal
+    default: /bin/true
+  chdir:
+    type: string
+    description: Change directory to here before searching for files
+    default: '{{dir}}'
+  architecture:
+    type: string
+    description: The architecture name. (usually matches `uname -a`). Use `all` for
+      noarch
+    default: x86_64
+  maintainer:
+    type: string
+    description: Maintainer of this package
+    default: root@product-flashflirt.stage.office.airg.lan
   cmd:
     default: fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration
-      {{revision}}
+      {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}}
+      --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}}
+      -p {{output_file}} {{input}}
     immutable: true

--- a/packs/fpm/actions/create_deb_from_rpm.yaml
+++ b/packs/fpm/actions/create_deb_from_rpm.yaml
@@ -35,10 +35,6 @@ parameters:
     type: string
     description: Package output type for fpm
     default: deb
-  output_file:
-    type: string
-    description: The package file path to output.
-    required: 'true'
   prefix:
     type: string
     description: A path to prefix files with when building the target package.
@@ -64,5 +60,5 @@ parameters:
     default: fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration
       {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}}
       --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}}
-      -p {{output_file}} {{input}}
+      {{input}}
     immutable: true

--- a/packs/fpm/actions/create_deb_from_rpm.yaml
+++ b/packs/fpm/actions/create_deb_from_rpm.yaml
@@ -9,24 +9,60 @@ parameters:
     type: string
     description: 'Package Name (e.g.: libpq)'
     required: true
+  description:
+    type: string
+    description: 'Package Description (e.g.: Provides PostgreSQL Client libs)'
+    default: Autobuilt package {{name}} by StackStorm + FPM Integration
   source:
     type: string
     description: Source type for fpm
     default: rpm
-  output:
-    type: string
-    description: Package output type for fpm
-    default: deb
   version:
     type: string
-    description: 'Package Versioni (e.g.: 0.1.1)'
+    description: 'Package Version (e.g.: 0.1.1)'
     required: true
   revision:
     type: string
     description: 'Package Revision (e.g: 2)'
     default: '1'
+  input:
+    type: string
+    description: Inputs to the source package type. For the 'dir' type, this is the
+      files and directories you want to include in the package. For others, like 'gem',
+      it specifies the packages to download and use as the gem input
     required: true
+  output:
+    type: string
+    description: Package output type for fpm
+    default: deb
+  output_file:
+    type: string
+    description: The package file path to output.
+    required: 'true'
+  prefix:
+    type: string
+    description: A path to prefix files with when building the target package.
+    default: /opt/{{name}}
+  after_install:
+    type: string
+    description: A script to be run after package removal
+    default: /bin/true
+  chdir:
+    type: string
+    description: Change directory to here before searching for files
+    default: '{{dir}}'
+  architecture:
+    type: string
+    description: The architecture name. (usually matches `uname -a`). Use `all` for
+      noarch
+    default: x86_64
+  maintainer:
+    type: string
+    description: Maintainer of this package
+    default: root@product-flashflirt.stage.office.airg.lan
   cmd:
     default: fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration
-      {{revision}}
+      {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}}
+      --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}}
+      -p {{output_file}} {{input}}
     immutable: true

--- a/packs/fpm/actions/create_deb_from_tar.yaml
+++ b/packs/fpm/actions/create_deb_from_tar.yaml
@@ -35,10 +35,6 @@ parameters:
     type: string
     description: Package output type for fpm
     default: deb
-  output_file:
-    type: string
-    description: The package file path to output.
-    required: 'true'
   prefix:
     type: string
     description: A path to prefix files with when building the target package.
@@ -64,5 +60,5 @@ parameters:
     default: fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration
       {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}}
       --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}}
-      -p {{output_file}} {{input}}
+      {{input}}
     immutable: true

--- a/packs/fpm/actions/create_deb_from_tar.yaml
+++ b/packs/fpm/actions/create_deb_from_tar.yaml
@@ -9,24 +9,60 @@ parameters:
     type: string
     description: 'Package Name (e.g.: libpq)'
     required: true
+  description:
+    type: string
+    description: 'Package Description (e.g.: Provides PostgreSQL Client libs)'
+    default: Autobuilt package {{name}} by StackStorm + FPM Integration
   source:
     type: string
     description: Source type for fpm
     default: tar
-  output:
-    type: string
-    description: Package output type for fpm
-    default: deb
   version:
     type: string
-    description: 'Package Versioni (e.g.: 0.1.1)'
+    description: 'Package Version (e.g.: 0.1.1)'
     required: true
   revision:
     type: string
     description: 'Package Revision (e.g: 2)'
     default: '1'
+  input:
+    type: string
+    description: Inputs to the source package type. For the 'dir' type, this is the
+      files and directories you want to include in the package. For others, like 'gem',
+      it specifies the packages to download and use as the gem input
     required: true
+  output:
+    type: string
+    description: Package output type for fpm
+    default: deb
+  output_file:
+    type: string
+    description: The package file path to output.
+    required: 'true'
+  prefix:
+    type: string
+    description: A path to prefix files with when building the target package.
+    default: /opt/{{name}}
+  after_install:
+    type: string
+    description: A script to be run after package removal
+    default: /bin/true
+  chdir:
+    type: string
+    description: Change directory to here before searching for files
+    default: '{{dir}}'
+  architecture:
+    type: string
+    description: The architecture name. (usually matches `uname -a`). Use `all` for
+      noarch
+    default: x86_64
+  maintainer:
+    type: string
+    description: Maintainer of this package
+    default: root@product-flashflirt.stage.office.airg.lan
   cmd:
     default: fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration
-      {{revision}}
+      {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}}
+      --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}}
+      -p {{output_file}} {{input}}
     immutable: true

--- a/packs/fpm/actions/create_rpm_from_deb.yaml
+++ b/packs/fpm/actions/create_rpm_from_deb.yaml
@@ -9,24 +9,60 @@ parameters:
     type: string
     description: 'Package Name (e.g.: libpq)'
     required: true
+  description:
+    type: string
+    description: 'Package Description (e.g.: Provides PostgreSQL Client libs)'
+    default: Autobuilt package {{name}} by StackStorm + FPM Integration
   source:
     type: string
     description: Source type for fpm
     default: deb
-  output:
-    type: string
-    description: Package output type for fpm
-    default: rpm
   version:
     type: string
-    description: 'Package Versioni (e.g.: 0.1.1)'
+    description: 'Package Version (e.g.: 0.1.1)'
     required: true
   revision:
     type: string
     description: 'Package Revision (e.g: 2)'
     default: '1'
+  input:
+    type: string
+    description: Inputs to the source package type. For the 'dir' type, this is the
+      files and directories you want to include in the package. For others, like 'gem',
+      it specifies the packages to download and use as the gem input
     required: true
+  output:
+    type: string
+    description: Package output type for fpm
+    default: rpm
+  output_file:
+    type: string
+    description: The package file path to output.
+    required: 'true'
+  prefix:
+    type: string
+    description: A path to prefix files with when building the target package.
+    default: /opt/{{name}}
+  after_install:
+    type: string
+    description: A script to be run after package removal
+    default: /bin/true
+  chdir:
+    type: string
+    description: Change directory to here before searching for files
+    default: '{{dir}}'
+  architecture:
+    type: string
+    description: The architecture name. (usually matches `uname -a`). Use `all` for
+      noarch
+    default: x86_64
+  maintainer:
+    type: string
+    description: Maintainer of this package
+    default: root@product-flashflirt.stage.office.airg.lan
   cmd:
     default: fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration
-      {{revision}}
+      {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}}
+      --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}}
+      -p {{output_file}} {{input}}
     immutable: true

--- a/packs/fpm/actions/create_rpm_from_deb.yaml
+++ b/packs/fpm/actions/create_rpm_from_deb.yaml
@@ -35,10 +35,6 @@ parameters:
     type: string
     description: Package output type for fpm
     default: rpm
-  output_file:
-    type: string
-    description: The package file path to output.
-    required: 'true'
   prefix:
     type: string
     description: A path to prefix files with when building the target package.
@@ -64,5 +60,5 @@ parameters:
     default: fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration
       {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}}
       --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}}
-      -p {{output_file}} {{input}}
+      {{input}}
     immutable: true

--- a/packs/fpm/actions/create_rpm_from_dir.yaml
+++ b/packs/fpm/actions/create_rpm_from_dir.yaml
@@ -9,24 +9,60 @@ parameters:
     type: string
     description: 'Package Name (e.g.: libpq)'
     required: true
+  description:
+    type: string
+    description: 'Package Description (e.g.: Provides PostgreSQL Client libs)'
+    default: Autobuilt package {{name}} by StackStorm + FPM Integration
   source:
     type: string
     description: Source type for fpm
     default: dir
-  output:
-    type: string
-    description: Package output type for fpm
-    default: rpm
   version:
     type: string
-    description: 'Package Versioni (e.g.: 0.1.1)'
+    description: 'Package Version (e.g.: 0.1.1)'
     required: true
   revision:
     type: string
     description: 'Package Revision (e.g: 2)'
     default: '1'
+  input:
+    type: string
+    description: Inputs to the source package type. For the 'dir' type, this is the
+      files and directories you want to include in the package. For others, like 'gem',
+      it specifies the packages to download and use as the gem input
     required: true
+  output:
+    type: string
+    description: Package output type for fpm
+    default: rpm
+  output_file:
+    type: string
+    description: The package file path to output.
+    required: 'true'
+  prefix:
+    type: string
+    description: A path to prefix files with when building the target package.
+    default: /opt/{{name}}
+  after_install:
+    type: string
+    description: A script to be run after package removal
+    default: /bin/true
+  chdir:
+    type: string
+    description: Change directory to here before searching for files
+    default: '{{dir}}'
+  architecture:
+    type: string
+    description: The architecture name. (usually matches `uname -a`). Use `all` for
+      noarch
+    default: x86_64
+  maintainer:
+    type: string
+    description: Maintainer of this package
+    default: root@product-flashflirt.stage.office.airg.lan
   cmd:
     default: fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration
-      {{revision}}
+      {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}}
+      --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}}
+      -p {{output_file}} {{input}}
     immutable: true

--- a/packs/fpm/actions/create_rpm_from_dir.yaml
+++ b/packs/fpm/actions/create_rpm_from_dir.yaml
@@ -35,10 +35,6 @@ parameters:
     type: string
     description: Package output type for fpm
     default: rpm
-  output_file:
-    type: string
-    description: The package file path to output.
-    required: 'true'
   prefix:
     type: string
     description: A path to prefix files with when building the target package.
@@ -64,5 +60,5 @@ parameters:
     default: fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration
       {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}}
       --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}}
-      -p {{output_file}} {{input}}
+      {{input}}
     immutable: true

--- a/packs/fpm/actions/create_rpm_from_empty.yaml
+++ b/packs/fpm/actions/create_rpm_from_empty.yaml
@@ -35,10 +35,6 @@ parameters:
     type: string
     description: Package output type for fpm
     default: rpm
-  output_file:
-    type: string
-    description: The package file path to output.
-    required: 'true'
   prefix:
     type: string
     description: A path to prefix files with when building the target package.
@@ -64,5 +60,5 @@ parameters:
     default: fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration
       {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}}
       --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}}
-      -p {{output_file}} {{input}}
+      {{input}}
     immutable: true

--- a/packs/fpm/actions/create_rpm_from_empty.yaml
+++ b/packs/fpm/actions/create_rpm_from_empty.yaml
@@ -9,24 +9,60 @@ parameters:
     type: string
     description: 'Package Name (e.g.: libpq)'
     required: true
+  description:
+    type: string
+    description: 'Package Description (e.g.: Provides PostgreSQL Client libs)'
+    default: Autobuilt package {{name}} by StackStorm + FPM Integration
   source:
     type: string
     description: Source type for fpm
     default: empty
-  output:
-    type: string
-    description: Package output type for fpm
-    default: rpm
   version:
     type: string
-    description: 'Package Versioni (e.g.: 0.1.1)'
+    description: 'Package Version (e.g.: 0.1.1)'
     required: true
   revision:
     type: string
     description: 'Package Revision (e.g: 2)'
     default: '1'
+  input:
+    type: string
+    description: Inputs to the source package type. For the 'dir' type, this is the
+      files and directories you want to include in the package. For others, like 'gem',
+      it specifies the packages to download and use as the gem input
     required: true
+  output:
+    type: string
+    description: Package output type for fpm
+    default: rpm
+  output_file:
+    type: string
+    description: The package file path to output.
+    required: 'true'
+  prefix:
+    type: string
+    description: A path to prefix files with when building the target package.
+    default: /opt/{{name}}
+  after_install:
+    type: string
+    description: A script to be run after package removal
+    default: /bin/true
+  chdir:
+    type: string
+    description: Change directory to here before searching for files
+    default: '{{dir}}'
+  architecture:
+    type: string
+    description: The architecture name. (usually matches `uname -a`). Use `all` for
+      noarch
+    default: x86_64
+  maintainer:
+    type: string
+    description: Maintainer of this package
+    default: root@product-flashflirt.stage.office.airg.lan
   cmd:
     default: fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration
-      {{revision}}
+      {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}}
+      --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}}
+      -p {{output_file}} {{input}}
     immutable: true

--- a/packs/fpm/actions/create_rpm_from_gem.yaml
+++ b/packs/fpm/actions/create_rpm_from_gem.yaml
@@ -35,10 +35,6 @@ parameters:
     type: string
     description: Package output type for fpm
     default: rpm
-  output_file:
-    type: string
-    description: The package file path to output.
-    required: 'true'
   prefix:
     type: string
     description: A path to prefix files with when building the target package.
@@ -64,5 +60,5 @@ parameters:
     default: fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration
       {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}}
       --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}}
-      -p {{output_file}} {{input}}
+      {{input}}
     immutable: true

--- a/packs/fpm/actions/create_rpm_from_gem.yaml
+++ b/packs/fpm/actions/create_rpm_from_gem.yaml
@@ -9,24 +9,60 @@ parameters:
     type: string
     description: 'Package Name (e.g.: libpq)'
     required: true
+  description:
+    type: string
+    description: 'Package Description (e.g.: Provides PostgreSQL Client libs)'
+    default: Autobuilt package {{name}} by StackStorm + FPM Integration
   source:
     type: string
     description: Source type for fpm
     default: gem
-  output:
-    type: string
-    description: Package output type for fpm
-    default: rpm
   version:
     type: string
-    description: 'Package Versioni (e.g.: 0.1.1)'
+    description: 'Package Version (e.g.: 0.1.1)'
     required: true
   revision:
     type: string
     description: 'Package Revision (e.g: 2)'
     default: '1'
+  input:
+    type: string
+    description: Inputs to the source package type. For the 'dir' type, this is the
+      files and directories you want to include in the package. For others, like 'gem',
+      it specifies the packages to download and use as the gem input
     required: true
+  output:
+    type: string
+    description: Package output type for fpm
+    default: rpm
+  output_file:
+    type: string
+    description: The package file path to output.
+    required: 'true'
+  prefix:
+    type: string
+    description: A path to prefix files with when building the target package.
+    default: /opt/{{name}}
+  after_install:
+    type: string
+    description: A script to be run after package removal
+    default: /bin/true
+  chdir:
+    type: string
+    description: Change directory to here before searching for files
+    default: '{{dir}}'
+  architecture:
+    type: string
+    description: The architecture name. (usually matches `uname -a`). Use `all` for
+      noarch
+    default: x86_64
+  maintainer:
+    type: string
+    description: Maintainer of this package
+    default: root@product-flashflirt.stage.office.airg.lan
   cmd:
     default: fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration
-      {{revision}}
+      {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}}
+      --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}}
+      -p {{output_file}} {{input}}
     immutable: true

--- a/packs/fpm/actions/create_rpm_from_python.yaml
+++ b/packs/fpm/actions/create_rpm_from_python.yaml
@@ -35,10 +35,6 @@ parameters:
     type: string
     description: Package output type for fpm
     default: rpm
-  output_file:
-    type: string
-    description: The package file path to output.
-    required: 'true'
   prefix:
     type: string
     description: A path to prefix files with when building the target package.
@@ -64,5 +60,5 @@ parameters:
     default: fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration
       {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}}
       --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}}
-      -p {{output_file}} {{input}}
+      {{input}}
     immutable: true

--- a/packs/fpm/actions/create_rpm_from_python.yaml
+++ b/packs/fpm/actions/create_rpm_from_python.yaml
@@ -9,24 +9,60 @@ parameters:
     type: string
     description: 'Package Name (e.g.: libpq)'
     required: true
+  description:
+    type: string
+    description: 'Package Description (e.g.: Provides PostgreSQL Client libs)'
+    default: Autobuilt package {{name}} by StackStorm + FPM Integration
   source:
     type: string
     description: Source type for fpm
     default: python
-  output:
-    type: string
-    description: Package output type for fpm
-    default: rpm
   version:
     type: string
-    description: 'Package Versioni (e.g.: 0.1.1)'
+    description: 'Package Version (e.g.: 0.1.1)'
     required: true
   revision:
     type: string
     description: 'Package Revision (e.g: 2)'
     default: '1'
+  input:
+    type: string
+    description: Inputs to the source package type. For the 'dir' type, this is the
+      files and directories you want to include in the package. For others, like 'gem',
+      it specifies the packages to download and use as the gem input
     required: true
+  output:
+    type: string
+    description: Package output type for fpm
+    default: rpm
+  output_file:
+    type: string
+    description: The package file path to output.
+    required: 'true'
+  prefix:
+    type: string
+    description: A path to prefix files with when building the target package.
+    default: /opt/{{name}}
+  after_install:
+    type: string
+    description: A script to be run after package removal
+    default: /bin/true
+  chdir:
+    type: string
+    description: Change directory to here before searching for files
+    default: '{{dir}}'
+  architecture:
+    type: string
+    description: The architecture name. (usually matches `uname -a`). Use `all` for
+      noarch
+    default: x86_64
+  maintainer:
+    type: string
+    description: Maintainer of this package
+    default: root@product-flashflirt.stage.office.airg.lan
   cmd:
     default: fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration
-      {{revision}}
+      {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}}
+      --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}}
+      -p {{output_file}} {{input}}
     immutable: true

--- a/packs/fpm/actions/create_rpm_from_rpm.yaml
+++ b/packs/fpm/actions/create_rpm_from_rpm.yaml
@@ -35,10 +35,6 @@ parameters:
     type: string
     description: Package output type for fpm
     default: rpm
-  output_file:
-    type: string
-    description: The package file path to output.
-    required: 'true'
   prefix:
     type: string
     description: A path to prefix files with when building the target package.
@@ -64,5 +60,5 @@ parameters:
     default: fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration
       {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}}
       --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}}
-      -p {{output_file}} {{input}}
+      {{input}}
     immutable: true

--- a/packs/fpm/actions/create_rpm_from_rpm.yaml
+++ b/packs/fpm/actions/create_rpm_from_rpm.yaml
@@ -9,24 +9,60 @@ parameters:
     type: string
     description: 'Package Name (e.g.: libpq)'
     required: true
+  description:
+    type: string
+    description: 'Package Description (e.g.: Provides PostgreSQL Client libs)'
+    default: Autobuilt package {{name}} by StackStorm + FPM Integration
   source:
     type: string
     description: Source type for fpm
     default: rpm
-  output:
-    type: string
-    description: Package output type for fpm
-    default: rpm
   version:
     type: string
-    description: 'Package Versioni (e.g.: 0.1.1)'
+    description: 'Package Version (e.g.: 0.1.1)'
     required: true
   revision:
     type: string
     description: 'Package Revision (e.g: 2)'
     default: '1'
+  input:
+    type: string
+    description: Inputs to the source package type. For the 'dir' type, this is the
+      files and directories you want to include in the package. For others, like 'gem',
+      it specifies the packages to download and use as the gem input
     required: true
+  output:
+    type: string
+    description: Package output type for fpm
+    default: rpm
+  output_file:
+    type: string
+    description: The package file path to output.
+    required: 'true'
+  prefix:
+    type: string
+    description: A path to prefix files with when building the target package.
+    default: /opt/{{name}}
+  after_install:
+    type: string
+    description: A script to be run after package removal
+    default: /bin/true
+  chdir:
+    type: string
+    description: Change directory to here before searching for files
+    default: '{{dir}}'
+  architecture:
+    type: string
+    description: The architecture name. (usually matches `uname -a`). Use `all` for
+      noarch
+    default: x86_64
+  maintainer:
+    type: string
+    description: Maintainer of this package
+    default: root@product-flashflirt.stage.office.airg.lan
   cmd:
     default: fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration
-      {{revision}}
+      {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}}
+      --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}}
+      -p {{output_file}} {{input}}
     immutable: true

--- a/packs/fpm/actions/create_rpm_from_tar.yaml
+++ b/packs/fpm/actions/create_rpm_from_tar.yaml
@@ -35,10 +35,6 @@ parameters:
     type: string
     description: Package output type for fpm
     default: rpm
-  output_file:
-    type: string
-    description: The package file path to output.
-    required: 'true'
   prefix:
     type: string
     description: A path to prefix files with when building the target package.
@@ -64,5 +60,5 @@ parameters:
     default: fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration
       {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}}
       --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}}
-      -p {{output_file}} {{input}}
+      {{input}}
     immutable: true

--- a/packs/fpm/actions/create_rpm_from_tar.yaml
+++ b/packs/fpm/actions/create_rpm_from_tar.yaml
@@ -9,24 +9,60 @@ parameters:
     type: string
     description: 'Package Name (e.g.: libpq)'
     required: true
+  description:
+    type: string
+    description: 'Package Description (e.g.: Provides PostgreSQL Client libs)'
+    default: Autobuilt package {{name}} by StackStorm + FPM Integration
   source:
     type: string
     description: Source type for fpm
     default: tar
-  output:
-    type: string
-    description: Package output type for fpm
-    default: rpm
   version:
     type: string
-    description: 'Package Versioni (e.g.: 0.1.1)'
+    description: 'Package Version (e.g.: 0.1.1)'
     required: true
   revision:
     type: string
     description: 'Package Revision (e.g: 2)'
     default: '1'
+  input:
+    type: string
+    description: Inputs to the source package type. For the 'dir' type, this is the
+      files and directories you want to include in the package. For others, like 'gem',
+      it specifies the packages to download and use as the gem input
     required: true
+  output:
+    type: string
+    description: Package output type for fpm
+    default: rpm
+  output_file:
+    type: string
+    description: The package file path to output.
+    required: 'true'
+  prefix:
+    type: string
+    description: A path to prefix files with when building the target package.
+    default: /opt/{{name}}
+  after_install:
+    type: string
+    description: A script to be run after package removal
+    default: /bin/true
+  chdir:
+    type: string
+    description: Change directory to here before searching for files
+    default: '{{dir}}'
+  architecture:
+    type: string
+    description: The architecture name. (usually matches `uname -a`). Use `all` for
+      noarch
+    default: x86_64
+  maintainer:
+    type: string
+    description: Maintainer of this package
+    default: root@product-flashflirt.stage.office.airg.lan
   cmd:
     default: fpm -s {{source}} -t {{output}} -n {{name}} --version {{version}} --iteration
-      {{revision}}
+      {{revision}} --prefix {{prefix}} --after-install {{after_install}} -C {{chdir}}
+      --maintainer {{maintainer}} --description "{{description}}" --architecture {{architecture}}
+      -p {{output_file}} {{input}}
     immutable: true

--- a/packs/fpm/actions/load_metadata.py
+++ b/packs/fpm/actions/load_metadata.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+import sys
+import json
+
+DIR=sys.argv.pop + sys.argv.pop
+metadata = open(DIR)
+print json.load(metadata)
+

--- a/packs/fpm/actions/load_metadata.yaml
+++ b/packs/fpm/actions/load_metadata.yaml
@@ -1,0 +1,15 @@
+---
+name: load_metadata
+description: Load package metadata from directory
+runner_type: run-remote
+enabled: true
+entry_point: ''
+parameters:
+  file:
+    type: string
+    description: File containing metadata
+    default: fpm.json
+    position: 2
+  cmd:
+    default: 'cat {{dir}}/{{file}}'
+    immutable: true

--- a/packs/fpm/config.yaml
+++ b/packs/fpm/config.yaml
@@ -1,0 +1,3 @@
+### Place configuration data for your pack here.
+---
+

--- a/packs/fpm/pack.yaml
+++ b/packs/fpm/pack.yaml
@@ -1,0 +1,8 @@
+### Place information about your pack version here.
+---
+name: fpm
+description: fpm
+version: 0.0.1
+author: jfryman
+email: jfryman@FryBook-2.local
+

--- a/packs/fpm/rules/README.md
+++ b/packs/fpm/rules/README.md
@@ -1,0 +1,3 @@
+# rules
+
+The rules folder contains rules. See [Rules](http://docs.stackstorm.com/rules.html) for specifics on writing rules.

--- a/packs/fpm/sensors/README.md
+++ b/packs/fpm/sensors/README.md
@@ -1,0 +1,4 @@
+# sensors
+
+The sensors folder contains sensoros. See [Sensors](http://docs.stackstorm.com/sensors.html) for specifics on writing
+sensors and registering TriggerTypes.

--- a/packs/json/actions/README.md
+++ b/packs/json/actions/README.md
@@ -1,0 +1,5 @@
+# actions
+
+The actions folder contains action scripts and metadata files. See [Actions](http://docs.stackstorm.com/actions.html)
+and [Workflows](http://docs.stackstorm.com/workflows.html) for specifics on writing actions. Note that the lib sub-folder
+is always available for access for an action script.

--- a/packs/json/actions/lib/parse.py
+++ b/packs/json/actions/lib/parse.py
@@ -1,0 +1,9 @@
+from st2actions.runners.pythonrunner import Action
+import json
+
+class ParseJson(Action):
+    def run(self, string):
+        try:
+            return json.loads(string)
+        except (ValueError, KeyError, TypeError):
+            print "JSON format error"

--- a/packs/json/actions/parse.yaml
+++ b/packs/json/actions/parse.yaml
@@ -1,0 +1,12 @@
+---
+name: parse
+description: Parse JSON string for use in workflows
+runner_type: run-python
+enabled: true
+entry_point: 'lib/parse.py'
+parameters:
+  string:
+    type: string
+    description: 'JSON Object to parse'
+    required: true
+

--- a/packs/json/config.yaml
+++ b/packs/json/config.yaml
@@ -1,0 +1,3 @@
+### Place configuration data for your pack here.
+---
+

--- a/packs/json/pack.yaml
+++ b/packs/json/pack.yaml
@@ -1,0 +1,8 @@
+### Place information about your pack version here.
+---
+name: json
+description: json
+version: 0.0.1
+author: jfryman
+email: jfryman@FryBook
+

--- a/packs/json/rules/README.md
+++ b/packs/json/rules/README.md
@@ -1,0 +1,3 @@
+# rules
+
+The rules folder contains rules. See [Rules](http://docs.stackstorm.com/rules.html) for specifics on writing rules.

--- a/packs/json/sensors/README.md
+++ b/packs/json/sensors/README.md
@@ -1,0 +1,4 @@
+# sensors
+
+The sensors folder contains sensoros. See [Sensors](http://docs.stackstorm.com/sensors.html) for specifics on writing
+sensors and registering TriggerTypes.


### PR DESCRIPTION
Holy CI/CD, Batman!

Here is a full-fledged Canary Build pipeline (just about) finished. For the whole shebang, check out https://github.com/StackStorm/discussions/issues/37. There seems to be one regression around Webhooks that has arisen since I last tested that, so I'll dig into that in the morning. However, this is it... in all it's gory details.

# Overview

This CI/CD Workflow is designed as a generic packaging and deployment pipeline. The aim here is to create a pipeline flexible enough to be able to push code of any type through, and prepare it for rapid deployment and management via StackStorm.

This workflow subscribes to the 'Convention over Configuration' approach to the world. Any project should be able to be used by this pipeline, assuming it follows these conventions:
  * CI Portion
    * A project exists on GitHub, and has its outgoing webhook configured to send to StackStorm
    * The project has two scripts designed to ensure the project is setup for  CI
      * `script/cisetup` - Prepares the build directory to run CI. Executed prior to CI begin
      * `script/cibuild` - Commands to test the execute the CI build process.
    * Project has been configured in on Jenkins Server
    * Project has a post-install script (`script/post-inst`) to do any items post-package installation.
    * (NOTE: Any of the scripts can simply `exit 0`, but they need to exist)
  * Consul has been configured to advertise servers with the following tags:
    * 'appname::approle'
    * 'appname::approle_canary'
    * By default, appname is the project name, and approle is `app`

The code as it currently stands can be found at: https://github.com/StackStorm/st2incubator/issues/35


## Design Decisions

This workflow was designed initially to cover the most generic use-case possible, and attempts to make assumptions about the operating environment that this could be used in. Specifically:

* The application language used should not be relevant to the pipeline
* The deploy mechanism must be native to the operating system
* Deploys should make best-effort at synchronous deployment, and also be eventually consistent

## Architecture

![cicd-components](https://cloud.githubusercontent.com/assets/20028/5621151/7f690d3e-94e7-11e4-950d-e5c8cb98adf5.png)



* Load Balancing: HAProxy
* Continuous Delivery
  * Asset: OS Packages
  * Strategy: Canary
* Continuous Integration Server: Jenkins
* Service Discovery: Consul
* Orchestration Layer: StackStorm
* Configuration Management: Puppet / Consul-Template
* Provisioning: Vagrant / EC2 / DigitalOcean



## Process Flow

![cicd-workflow](https://cloud.githubusercontent.com/assets/20028/5620939/7ae8e4de-94e5-11e4-88ed-527fc285c11a.png)


1. User pushes new commit to GitHub
2. [GitHub] Fires a webhook to StackStorm
3. [StackStorm :: Web Hook] StackStorm receives the webhook, and matches it to an incoming rule to begin a CI Job
4. [Jenkins] Clones application from GitHub
5. [Jenkins] On build completion, sends a webhook back to StackStorm with Success/Failure
6. [Jenkins :: Success] StackStorm kicks off packaging workflow to build an OS package from the application.
7. [Package] StackStorm queries Consul for an available host to build a package
8. [Package] StackStorm downloads the application from GitHub
9. [Package] StackStorm queries the downloaded repository for metadata to build the package
10. [Package] StackStorm packages up the repository using FPM
11. [Package] StackStorm takes the package and inserts it into Freight (APT Repository), marking it eligible for download
12. [Package] StackStorm cleans up all tempfiles and hands off to Deploy Workflow
13. [Deploy :: Canary] StackStorm updates the currently advertised version of the application to deploy.
14. [Deploy :: Canary] StackStorm queries all hosts that have been tagged as 'canary'
15. [Deploy :: Canary] StackStorm tells all canary hosts a package has been updated, and updates the servers.
16. User waits for any external alarms to fire (New Relic, Nagios, etc).
17. If no failures, user deploys new package to production.
18. [Deploy :: Production] StackStorm updates the currently advertised version to the currently deployed canary version
19. [Deploy :: Production] StackStorm tells all production hosts a package has been updated, and updates the servers.
