### PR TITLE
changed rules to get ci_host from datastore

### DIFF
--- a/packs/st2cd/rules/st2_test_upgrade_master_staging.yaml
+++ b/packs/st2cd/rules/st2_test_upgrade_master_staging.yaml
@@ -17,7 +17,7 @@
     action:
         ref: "st2cd.integration_tests"
         parameters:
-            hostname: "st2stage201"
+            hostname: "{{system.st2_ci_host}}"
             repo: "{{trigger.parameters.repo}}"
             branch: "{{trigger.parameters.branch}}"
             environment: "{{trigger.parameters.environment}}"

--- a/packs/st2cd/rules/st2_upgrade_master_staging.yaml
+++ b/packs/st2cd/rules/st2_upgrade_master_staging.yaml
@@ -19,7 +19,7 @@
         parameters:
             action: "core.local"
             action_params: "hostname"
-            hostname: "st2stage201"
+            hostname: "{{system.st2_ci_host}}"
             repo: "{{trigger.parameters.repo}}"
             branch: "{{trigger.parameters.branch}}"
             environment: "{{trigger.parameters.environment}}"


### PR DESCRIPTION
Changed hardcoded host name to use datastore.
