### PR TITLE
Pwh/create vm

### DIFF
--- a/packs/st2cd/actions/create_vm.meta.yaml
+++ b/packs/st2cd/actions/create_vm.meta.yaml
@@ -13,10 +13,10 @@
       type: "string"
       description: "Flavor of to use for instance creation"
       default: "t2.medium"
-    subnet_id:
+    environment:
       type: "string"
-      description: "ID of the subnet to launch instance in"
-      default: "subnet-23b66654"
+      description: "Environment to deploy to"
+      default: "staging"
     key_name:
       type: "string"
       description: "SSH key to use during intial instance creation"

--- a/packs/st2cd/actions/workflows/create_vm.yaml
+++ b/packs/st2cd/actions/workflows/create_vm.yaml
@@ -1,12 +1,26 @@
 ---
   chain:
     -
+      name: "get_subnet_id"
+      ref: "st2cd.kvstore"
+      params:
+        key: "{{environment}}_subnet"
+        action: "get"
+      on-success: "get_apt_repo"
+    -
+      name: "get_apt_repo"
+      ref: "st2cd.kvstore"
+      params:
+        key: "apt_repo_{{environment}}"
+        action: "get"
+      on-success: "run_instance"
+    -
       name: "run_instance"
       ref: "aws.ec2_run_instances"
       params:
         image_id: "{{image_id}}"
         instance_type: "{{instance_type}}"
-        subnet_id: "{{subnet_id}}"
+        subnet_id: "{{get_subnet_id.result}}"
         key_name: "{{key_name}}"
       on-success: "wait_for_instance"
     -
@@ -47,7 +61,7 @@
       params:
         hosts: "{{run_instance.result[0][0].private_ip_address}}"
         name: "stackstorm"
-        repo: "http://{{system.apt_repo_staging}}/deb/"
+        repo: "http://{{get_apt_repo.result}}/deb/"
       on-success: "get_apt_key"
     -
       name: "get_apt_key"
@@ -55,7 +69,7 @@
       params:
         hosts: "{{run_instance.result[0][0].private_ip_address}}"
         name: "stackstorm"
-        url: "http://{{system.apt_repo_staging}}/deb/keyring.gpg"
+        url: "http://{{get_apt_repo.result}}/deb/keyring.gpg"
       on-success: "set_hostname"
     -
       name: "set_hostname"
@@ -87,4 +101,4 @@
       ref: "st2cd.puppet_bootstrap"
       params:
         hosts: "{{run_instance.result[0][0].private_dns_name}}"
-  default: "run_instance"
+  default: "get_subnet_id"

--- a/packs/st2cd/rules/st2_upgrade_master_nightly.yaml
+++ b/packs/st2cd/rules/st2_upgrade_master_nightly.yaml
@@ -1,0 +1,28 @@
+---
+    name: "st2_upgrade_master_nightly"
+    description: "Upgrade StackStorm on staging hosts nightly"
+    enabled: true
+    trigger:
+        type: "core.st2.IntervalTimer"
+        parameters:
+            hour: 20
+            minute: 0
+    criteria:
+        trigger.action_name:
+            pattern: "st2cd.packaging"
+            type: "equals"
+        trigger.status:
+            pattern: "succeeded"
+            type: "equals"
+        trigger.parameters.environment:
+            pattern: "staging"
+            type: "equals"
+    action:
+        ref: "st2cd.st2_upgrade"
+        parameters:
+            action: "core.local"
+            action_params: "hostname"
+            hostname: "{{system.st2_nightly_host}}"
+            repo: "{{trigger.parameters.repo}}"
+            branch: "{{trigger.parameters.branch}}"
+            environment: "{{trigger.parameters.environment}}"


### PR DESCRIPTION
This removes the subnet_id parameter from the create_vm workflow.  It also adds an 'environment' parameter and updates the workflow to look up the appropriate subnet and apt repo based on the environment.