### PR TITLE
st2web deployment workflow

### DIFF
--- a/packs/st2cd/actions/st2_web_deploy.meta.yaml
+++ b/packs/st2cd/actions/st2_web_deploy.meta.yaml
@@ -12,7 +12,7 @@
     repo_url:
       type: "string"
       description: "Composite url including token"
-      immutable: "true"
+      immutable: true
       default: "https://{{auth_string}}github.com/{{repo_path}}"
     token:
       type: "string"
@@ -23,7 +23,7 @@
       type: "string"
       description: "Composite auth string based on token param"
       immutable: true
-      default: "{% if token != "" -%}{{token}}:x-oauth-basic@{% endif -%}"
+      default: "{% if token != '' -%}{{token}}:x-oauth-basic@{% endif -%}"
     hostname:
       type: "string"
       description: "Hostname to deploy st2web on"
@@ -36,3 +36,11 @@
       type: "string"
       description: "The branch to clone"
       default: "master"
+    revision:
+      type: "string"
+      description: ""
+      required: false
+    author:
+      type: "string"
+      description: ""
+      required: false

--- a/packs/st2cd/actions/st2_web_deploy.meta.yaml
+++ b/packs/st2cd/actions/st2_web_deploy.meta.yaml
@@ -1,0 +1,38 @@
+---
+  name: "st2_web_deploy"
+  runner_type: "action-chain"
+  description: "Deploys the latest st2web on a server"
+  enabled: true
+  entry_point: "workflows/st2_web_deploy.yaml"
+  parameters:
+    repo_path:
+      type: "string"
+      description: "Relative GitHub repo path [USERNAME/REPO.git]"
+      default: "StackStorm/st2web.git"
+    repo_url:
+      type: "string"
+      description: "Composite url including token"
+      immutable: "true"
+      default: "https://{{auth_string}}github.com/{{repo_path}}"
+    token:
+      type: "string"
+      description: "GitHub OAuth Token"
+      required: true
+      default: ""
+    auth_string:
+      type: "string"
+      description: "Composite auth string based on token param"
+      immutable: true
+      default: "{% if token != "" -%}{{token}}:x-oauth-basic@{% endif -%}"
+    hostname:
+      type: "string"
+      description: "Hostname to deploy st2web on"
+      required: true
+    backup_dir:
+      type: "string"
+      description: "Location to backup old st2web to"
+      default: "/home/stanley/backup"
+    branch:
+      type: "string"
+      description: "The branch to clone"
+      default: "master"

--- a/packs/st2cd/actions/st2_web_rollback.meta.yaml
+++ b/packs/st2cd/actions/st2_web_rollback.meta.yaml
@@ -1,0 +1,15 @@
+---
+  name: "st2_web_rollback"
+  runner_type: "action-chain"
+  description: "Rolls back to previous st2web"
+  enabled: true
+  entry_point: "workflows/st2_web_rollback.yaml"
+  parameters:
+    hostname:
+      type: "string"
+      description: "Hostname to deploy st2web on"
+      required: true
+    backup_dir:
+      type: "string"
+      description: "Location to backup old st2web to"
+      default: "/home/stanley/backup"

--- a/packs/st2cd/actions/workflows/st2_web_deploy.yaml
+++ b/packs/st2cd/actions/workflows/st2_web_deploy.yaml
@@ -7,7 +7,7 @@
         hosts: "{{hostname}}"
         cmd: "screen -S st2web -X quit"
       on-success: "current_timestamp"
-      on-failure: "slack_failure"
+      on-failure: "current_timestamp"
     -
       name: "curent_timestamp"
       ref: "core.local"
@@ -21,11 +21,11 @@
       params:
         hosts: "{{hostname}}"
         source: "/home/stanley/st2web"
-        destination: "/home/stanley/{{backup_dir}}_{{current_timestamp.localhost.stdout}}"
+        destination: "{{backup_dir}}/{{current_timestamp.localhost.stdout}}"
         recursive: true
         force: true
       on-success: "clone_repo"
-      on-failure: "slack_failure"
+      on-failure: "clone_repo"
     -
       name: "clone_repo"
       ref: "st2cd.git_clone"

--- a/packs/st2cd/actions/workflows/st2_web_deploy.yaml
+++ b/packs/st2cd/actions/workflows/st2_web_deploy.yaml
@@ -6,23 +6,33 @@
       params:
         hosts: "{{hostname}}"
         cmd: "screen -S st2web -X quit"
-      on-success: "current_timestamp"
-      on-failure: "current_timestamp"
+      on-success: "mv_previous_timestamp"
+      on-failure: "mv_previous_timestamp"
     -
-      name: "curent_timestamp"
-      ref: "core.local"
+      name: "mv_previous_timestamp"
+      ref: "linux.mv"
       params:
-        cmd: "date +%s | tee /home/stanley/PREVIOUS_WEB"
+        hosts: "{{hostname}}"
+        source: "/home/stanley/CURRENT_WEB"
+        destination: "/home/stanley/PREVIOUS_WEB"
+        force: true
+      on-success: "previous"
+      on-failure: "previous"
+    -
+      name: "previous"
+      ref: "core.remote"
+      params:
+        hosts: "{{hostname}}"
+        cmd: "cat /home/stanley/PREVIOUS_WEB"
       on-success: "backup_repo"
-      on-failure: "slack_failure"
+      on-failure: "backup_repo"
     -
       name: "backup_repo"
       ref: "linux.mv"
       params:
         hosts: "{{hostname}}"
-        source: "/home/stanley/st2web"
-        destination: "{{backup_dir}}/{{current_timestamp.localhost.stdout}}"
-        recursive: true
+        source: "{{previous[hostname].stdout}}"
+        destination: "{{backup_dir}}/"
         force: true
       on-success: "clone_repo"
       on-failure: "clone_repo"
@@ -34,6 +44,14 @@
         repo: "{{repo_url}}"
         branch: "{{branch}}"
         target: "st2web"
+      on-success: "current"
+      on-failure: "slack_failure"
+    -
+      name: "current"
+      ref: "core.remote"
+      params:
+        hosts: "{{hostname}}"
+        cmd: "echo {{clone_repo[hostname].stdout}} > /home/stanley/CURRENT_WEB"
       on-success: "npm_install"
       on-failure: "slack_failure"
     -
@@ -41,7 +59,7 @@
       ref: "core.remote"
       params:
         hosts: "{{hostname}}"
-        cmd: "cd /home/stanley/st2web && npm install"
+        cmd: "cd {{clone_repo[hostname].stdout}} && npm install"
       on-success: "bower_install"
       on-failure: "slack_failure"
     -
@@ -49,7 +67,7 @@
       ref: "core.remote"
       params:
         hosts: "{{hostname}}"
-        cmd: "cd /home/stanley/st2web && bower install"
+        cmd: "cd {{clone_repo[hostname].stdout}} && bower install"
       on-success: "update_st2_config"
       on-failure: "slack_failure"
     -
@@ -58,7 +76,7 @@
       params:
         hosts: "{{hostname}}"
         sudo: true
-        cmd: 'sed -e "s~# \(allow_origin = \).*~\1 http://{{hostname}}:3000~g" /etc/st2/st2.conf'
+        cmd: 'sed -i -e "s~# \(allow_origin = \).*~\1 \*~g" /etc/st2/st2.conf'
       on-success: "update_web_config"
       on-failure: "slack_failure"
     -
@@ -66,7 +84,16 @@
       ref: "core.remote"
       params:
         hosts: "{{hostname}}"
-        cmd: 'sed -e "s~Express~`hostname -s`~g" -e "s~172\.168\.90\.50~{{hostname}}~g" /home/stanley/st2web/config.js'
+        cmd: 'sed -i -e "s~Express~`hostname -s`~g" -e "s~172\.168\.90\.50~{{hostname}}~g" {{clone_repo[hostname].stdout}}/config.js'
+      on-success: "restart_st2"
+      on-failure: "slack_failure"
+    -
+      name: "restart_st2"
+      ref: "core.remote_sudo"
+      params:
+        hosts: "{{hostname}}"
+        sudo: true
+        cmd: "st2ctl restart"
       on-success: "gulp_in_screen"
       on-failure: "slack_failure"
     -
@@ -74,7 +101,7 @@
       ref: "core.remote"
       params:
         hosts: "{{hostname}}"
-        cmd: "cd /home/stanley/st2web && screen -S st2web -d -m gulp"
+        cmd: "cd {{clone_repo[hostname].stdout}} && screen -S st2web -d -m gulp"
       on-success: "slack_success"
       on-failure: "slack_failure"
     -
@@ -82,12 +109,12 @@
       ref: "slack.post_message"
       params:
         channel: "#thunderdome"
-        message: "```[st2web deploy]\n STATUS: SUCCESS\n HOSTNAME: {{hostname}}\n BRANCH: {{branch}}```"
+        message: "```[st2web deploy]\n STATUS: SUCCESS\n HOSTNAME: {{hostname}}\n BRANCH: {{branch}}\n SHA: {{revision}}\n URL: http://{{hostname}}:3000```"
     -
       name: "slack_failure"
       ref: "slack.post_message"
       params:
         channel: "#thunderdome"
-        message: "```[st2web deploy]\n STATUS: FAILURE\n HOSTNAME: {{hostname}}\n BRANCH: {{branch}}```"
+        message: "```[st2web deploy]\n STATUS: FAILURE\n HOSTNAME: {{hostname}}\n BRANCH: {{branch}}\n SHA: {{revision}}```"
 
   default: "stop_st2web"

--- a/packs/st2cd/actions/workflows/st2_web_deploy.yaml
+++ b/packs/st2cd/actions/workflows/st2_web_deploy.yaml
@@ -1,11 +1,20 @@
 ---
   chain:
     -
+      name: "stop_st2web"
+      ref: "core.remote"
+      params:
+        hosts: "{{hostname}}"
+        cmd: "screen -S st2web -X quit"
+      on-success: "current_timestamp"
+      on-failure: "slack_failure"
+    -
       name: "curent_timestamp"
       ref: "core.local"
       params:
-        cmd: "date +%s"
+        cmd: "date +%s | tee /home/stanley/PREVIOUS_WEB"
       on-success: "backup_repo"
+      on-failure: "slack_failure"
     -
       name: "backup_repo"
       ref: "linux.mv"
@@ -16,6 +25,7 @@
         recursive: true
         force: true
       on-success: "clone_repo"
+      on-failure: "slack_failure"
     -
       name: "clone_repo"
       ref: "st2cd.git_clone"
@@ -25,6 +35,7 @@
         branch: "{{branch}}"
         target: "st2web"
       on-success: "npm_install"
+      on-failure: "slack_failure"
     -
       name: "npm_install"
       ref: "core.remote"
@@ -32,6 +43,7 @@
         hosts: "{{hostname}}"
         cmd: "cd /home/stanley/st2web && npm install"
       on-success: "bower_install"
+      on-failure: "slack_failure"
     -
       name: "bower_install"
       ref: "core.remote"
@@ -39,38 +51,43 @@
         hosts: "{{hostname}}"
         cmd: "cd /home/stanley/st2web && bower install"
       on-success: "update_st2_config"
+      on-failure: "slack_failure"
     -
       name: "update_st2_config"
-      ref: "core.remote"
+      ref: "core.remote_sudo"
       params:
         hosts: "{{hostname}}"
-        cmd: ""
+        sudo: true
+        cmd: 'sed -e "s~# \(allow_origin = \).*~\1 http://{{hostname}}:3000~g" /etc/st2/st2.conf'
       on-success: "update_web_config"
+      on-failure: "slack_failure"
     -
       name: "update_web_config"
       ref: "core.remote"
       params:
         hosts: "{{hostname}}"
-        cmd: ""
+        cmd: 'sed -e "s~Express~`hostname -s`~g" -e "s~172\.168\.90\.50~{{hostname}}~g" /home/stanley/st2web/config.js'
       on-success: "gulp_in_screen"
+      on-failure: "slack_failure"
     -
       name: "gulp_in_screen"
       ref: "core.remote"
       params:
         hosts: "{{hostname}}"
-        cmd: "install -y"
+        cmd: "cd /home/stanley/st2web && screen -S st2web -d -m gulp"
       on-success: "slack_success"
+      on-failure: "slack_failure"
     -
       name: "slack_success"
       ref: "slack.post_message"
       params:
         channel: "#thunderdome"
-        message: "st2ctl reload && nohup bg st2ctl restart >& /dev/null < /dev/null; sleep 20"
+        message: "```[st2web deploy]\n STATUS: SUCCESS\n HOSTNAME: {{hostname}}\n BRANCH: {{branch}}```"
     -
       name: "slack_failure"
       ref: "slack.post_message"
       params:
-        channel: "{{hostname}}"
-        message: "update"
+        channel: "#thunderdome"
+        message: "```[st2web deploy]\n STATUS: FAILURE\n HOSTNAME: {{hostname}}\n BRANCH: {{branch}}```"
 
-  default: "current_timestamp"
+  default: "stop_st2web"

--- a/packs/st2cd/actions/workflows/st2_web_deploy.yaml
+++ b/packs/st2cd/actions/workflows/st2_web_deploy.yaml
@@ -1,0 +1,76 @@
+---
+  chain:
+    -
+      name: "curent_timestamp"
+      ref: "core.local"
+      params:
+        cmd: "date +%s"
+      on-success: "backup_repo"
+    -
+      name: "backup_repo"
+      ref: "linux.mv"
+      params:
+        hosts: "{{hostname}}"
+        source: "/home/stanley/st2web"
+        destination: "/home/stanley/{{backup_dir}}_{{current_timestamp.localhost.stdout}}"
+        recursive: true
+        force: true
+      on-success: "clone_repo"
+    -
+      name: "clone_repo"
+      ref: "st2cd.git_clone"
+      params:
+        hosts: "{{hostname}}"
+        repo: "{{repo_url}}"
+        branch: "{{branch}}"
+        target: "st2web"
+      on-success: "npm_install"
+    -
+      name: "npm_install"
+      ref: "core.remote"
+      params:
+        hosts: "{{hostname}}"
+        cmd: "cd /home/stanley/st2web && npm install"
+      on-success: "bower_install"
+    -
+      name: "bower_install"
+      ref: "core.remote"
+      params:
+        hosts: "{{hostname}}"
+        cmd: "cd /home/stanley/st2web && bower install"
+      on-success: "update_st2_config"
+    -
+      name: "update_st2_config"
+      ref: "core.remote"
+      params:
+        hosts: "{{hostname}}"
+        cmd: ""
+      on-success: "update_web_config"
+    -
+      name: "update_web_config"
+      ref: "core.remote"
+      params:
+        hosts: "{{hostname}}"
+        cmd: ""
+      on-success: "gulp_in_screen"
+    -
+      name: "gulp_in_screen"
+      ref: "core.remote"
+      params:
+        hosts: "{{hostname}}"
+        cmd: "install -y"
+      on-success: "slack_success"
+    -
+      name: "slack_success"
+      ref: "slack.post_message"
+      params:
+        channel: "#thunderdome"
+        message: "st2ctl reload && nohup bg st2ctl restart >& /dev/null < /dev/null; sleep 20"
+    -
+      name: "slack_failure"
+      ref: "slack.post_message"
+      params:
+        channel: "{{hostname}}"
+        message: "update"
+
+  default: "current_timestamp"

--- a/packs/st2cd/actions/workflows/st2_web_rollback.yaml
+++ b/packs/st2cd/actions/workflows/st2_web_rollback.yaml
@@ -1,0 +1,76 @@
+---
+  chain:
+    -
+      name: "stop_st2web"
+      ref: "core.remote"
+      params:
+        hosts: "{{hostname}}"
+        cmd: "screen -S st2web -X quit"
+      on-success: "previous"
+      on-failure: "previous"
+    -
+      name: "previous"
+      ref: "core.remote"
+      params:
+        hosts: "{{hostname}}"
+        cmd: "cat /home/stanley/PREVIOUS_WEB"
+      on-success: "restore_repo"
+      on-failure: "slack_failure"
+    -
+      name: "restore_repo"
+      ref: "linux.mv"
+      params:
+        hosts: "{{hostname}}"
+        source: "{{backup_dir}}/{{previous[hostname].stdout}}"
+        destination: "/home/stanley/"
+        force: true
+      on-success: "restore_current_web"
+      on-failure: "slack_failure"
+    -
+      name: "restore_current_web"
+      ref: "linux.mv"
+      params:
+        hosts: "{{hostname}}"
+        source: "/home/stanley/PREVIOUS_WEB"
+        destination: "/home/stanley/CURRENT_WEB"
+        force: true
+      on-success: "npm_install"
+      on-failure: "slack_failure"
+    -
+      name: "npm_install"
+      ref: "core.remote"
+      params:
+        hosts: "{{hostname}}"
+        cmd: "cd /home/stanley/{{previous[hostname].stdout}} && npm install"
+      on-success: "bower_install"
+      on-failure: "slack_failure"
+    -
+      name: "bower_install"
+      ref: "core.remote"
+      params:
+        hosts: "{{hostname}}"
+        cmd: "cd /home/stanley/{{previous[hostname].stdout}} && bower install"
+      on-success: "gulp_in_screen"
+      on-failure: "slack_failure"
+    -
+      name: "gulp_in_screen"
+      ref: "core.remote"
+      params:
+        hosts: "{{hostname}}"
+        cmd: "cd /home/stanley/{{previous[hostname].stdout}} && screen -S st2web -d -m gulp"
+      on-success: "slack_success"
+      on-failure: "slack_failure"
+    -
+      name: "slack_success"
+      ref: "slack.post_message"
+      params:
+        channel: "#thunderdome"
+        message: "```[st2web rollback]\n STATUS: SUCCESS\n HOSTNAME: {{hostname}}\n CURRENT_WEB: {{previous[hostname].stdout}}\n URL: http://{{hostname}}:3000```"
+    -
+      name: "slack_failure"
+      ref: "slack.post_message"
+      params:
+        channel: "#thunderdome"
+        message: "```[st2web rollback]\n STATUS: FAILURE\n HOSTNAME: {{hostname}}\n ```"
+
+  default: "stop_st2web"


### PR DESCRIPTION
This adds two workflows:
* st2_web_deploy
* st2_web_rollback

and a rule:
* st2_web_master_staging

The rule looks for post commit messages on the st2web repo master branch.  On a matching event it fires the st2_web_deploy workflow to upgrade st2web to TOT on whichever host is listed as the CI host in the datastore.

Here is the help output of the deploy workflow: 
```
Deploys the latest st2web on a server

Required Parameters:
    hostname
        Hostname to deploy st2web on
        Type: string

    token
        GitHub OAuth Token
        Type: string
        Default:

Optional Parameters:
    author
        Type: string

    backup_dir
        Location to backup old st2web to
        Type: string
        Default: /home/stanley/backup

    branch
        The branch to clone
        Type: string
        Default: master

    repo_path
        Relative GitHub repo path [USERNAME/REPO.git]
        Type: string
        Default: StackStorm/st2web.git

    revision
        Type: string
```

In case of an issue the rollback workflow can be used to revert to the previous version.
```
Rolls back to previous st2web

Required Parameters:
    hostname
        Hostname to deploy st2web on
        Type: string

Optional Parameters:
    backup_dir
        Location to backup old st2web to
        Type: string
        Default: /home/stanley/backup
```

Both workflows will post to #thunderdome in Slack on success or failure.
