### PR TITLE
Pack for mistral development

### DIFF
--- a/packs/mistral-dev/actions/switch.sh
+++ b/packs/mistral-dev/actions/switch.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Terminate on error.
+set -e
+
+# Setup variables.
+ST2_REPO_ROOT=$1
+OS_REPO_ROOT=$2
+REPO=$3
+BRANCH=$4
+
+OPT_DIR=/opt/openstack
+
+if [[ "${REPO}" = "st2" ]]; then
+    SWITCH_TO=${ST2_REPO_ROOT}
+else
+    SWITCH_TO=${OS_REPO_ROOT}    
+fi
+
+# Exit if expected paths do not exist.
+FOLDERS=(
+    "${SWITCH_TO}"
+    "${SWITCH_TO}/mistral"
+    "${SWITCH_TO}/python-mistralclient"
+)
+
+for i in "${FOLDERS[@]}"
+do
+    if [[ ! -d "${i}" ]]; then
+        echo "The path ${i} does not exist."
+        exit 1
+    fi
+done
+
+# Switch the symbolic link for mistral.
+if [[ ! -d ${OPT_DIR} ]]; then
+    echo "Creating directory ${OPT_DIR}..."
+    mkdir -p ${OPT_DIR}
+fi
+
+cd ${OPT_DIR}
+if [[ -L ${OPT_DIR}/mistral ]]; then
+    rm mistral
+fi
+ln -s ${SWITCH_TO}/mistral mistral
+
+# Reinstall the python-mistralclient.
+cd ${SWITCH_TO}/python-mistralclient
+python setup.py develop
+
+# Restart the mistral service appropriately.
+SERVICE_STATUS=`service mistral status`
+IS_SERVICE_RUNNING=`echo ${SERVICE_STATUS} | grep "running"`
+if [[ "${IS_SERVICE_RUNNING}" != "" ]]; then
+    echo ""
+    echo "Restarting mistral service..."
+    service mistral restart
+fi

--- a/packs/mistral-dev/actions/switch.yaml
+++ b/packs/mistral-dev/actions/switch.yaml
@@ -1,0 +1,41 @@
+---
+name: "switch"
+pack: "mistral-dev"
+runner_type: "run-local-script"
+description: "Switch between the stackstorm/mistral and stackforge/mistral repo for development."
+enabled: true
+entry_point: "switch.sh"
+parameters:
+  st2_repo_root:
+    type: "string"
+    description: "Local root path to the StackStorm repositories."
+    position: 0
+    default: "/home/vagrant/code/stackstorm"
+  os_repo_root:
+    type: "string"
+    description: "Local root path to the OpenStack/StackForge repositories."
+    position: 1
+    default: "/home/vagrant/code/openstack"
+  repo:
+    enum:
+        - st2
+        - os
+    description: "Swap to either the StackStorm or OpenStack/StackForge repo."
+    position: 2
+    required: true
+  branch:
+    type: "string"
+    description: "Checkout the given branch for the repo."
+    position: 3
+  cmd:
+    immutable: true
+    default: ""
+  sudo:
+    immutable: true
+    default: true
+  cwd:
+    immutable: true
+    default: "."
+  kwarg_op:
+    immutable: true
+    default: "--"

--- a/packs/mistral-dev/pack.yaml
+++ b/packs/mistral-dev/pack.yaml
@@ -1,0 +1,6 @@
+---
+name : mistral-dev
+description : st2 content pack for mistral development.
+version : 0.1
+author : st2-dev
+email : info@stackstorm.com


### PR DESCRIPTION
Initial pack to manage mistral development environments. The
mistral-dev.switch action allows developers to switch between the
stackstorm/mistral and stackforge/mistral github repositories. The
action assumes github repositories are cloned locally.