### PR TITLE
Remove .pypirc file after build

### DIFF
--- a/packs/st2cd/actions/workflows/st2_packaging_st2client.yaml
+++ b/packs/st2cd/actions/workflows/st2_packaging_st2client.yaml
@@ -58,6 +58,13 @@
       params:
         hosts: "{{get_build_server.result[0]}}"
         repo: "{{clone_repo[get_build_server.result[0]].stdout}}"
+      on-success: "remove_pypirc"
+    -
+      name: "remove_pypirc"
+      ref: "core.remote"
+      params:
+        hosts: "{{get_build_server.result[0]}}"
+        cmd: "rm -f ~/.pypirc"
       on-success: "clean_repo"
     - 
       name: "clean_repo"


### PR DESCRIPTION
Clean up and remove the ~/.pypirc file from the environment.