### PR TITLE
Minor fixes to workflow for uploading st2client to pypi

### DIFF
--- a/packs/st2cd/actions/st2_packaging_st2client.meta.yaml
+++ b/packs/st2cd/actions/st2_packaging_st2client.meta.yaml
@@ -18,10 +18,3 @@
       description: "The branch to build"
       default: "master"
       required: true
-    dl_server:
-      type: "string"
-      description: ""
-      required: true
-    environment:
-      type: "string"
-      description: ""

--- a/packs/st2cd/actions/write_pypirc.sh
+++ b/packs/st2cd/actions/write_pypirc.sh
@@ -14,8 +14,8 @@ touch ${PYPIRC}
 cat <<pypirc >${PYPIRC}
 [distutils]
 index-servers =
-    pypi
-    pypitest
+    pypi
+    pypitest
 
 [pypi]
 repository: https://pypi.python.org/pypi

--- a/packs/st2cd/actions/write_pypirc.yaml
+++ b/packs/st2cd/actions/write_pypirc.yaml
@@ -5,12 +5,12 @@
   enabled: true
   entry_point: "write_pypirc.sh"
   parameters:
-    username: 
+    pypi_username: 
       type: "string"
       description: "PyPI account username"
       default: "{{system.st2_pypi_username}}"
       position: 0
-    password: 
+    pypi_password: 
       type: "string"
       description: "PyPI account password"
       default: "{{system.st2_pypi_password}}"


### PR DESCRIPTION
Remove unneeded parameters from the st2_packaging_st2client action, remove special chars from .pypirc file, and rename username/password parameters in the write_pypirc action.