### PR TITLE
Baseline pack deployment via ChatOps

### DIFF
--- a/packs/deploy/actions/README.md
+++ b/packs/deploy/actions/README.md
@@ -1,0 +1,5 @@
+# actions
+
+The actions folder contains action scripts and metadata files. See [Actions](http://docs.stackstorm.com/actions.html)
+and [Workflows](http://docs.stackstorm.com/workflows.html) for specifics on writing actions. Note that the lib sub-folder
+is always available for access for an action script.

--- a/packs/deploy/actions/merge.py
+++ b/packs/deploy/actions/merge.py
@@ -1,0 +1,5 @@
+from st2actions.runners.pythonrunner import Action
+
+class Merge(Action):
+    def run(self, defaults, overrides):
+        return dict(defaults.items() + overrides.items())

--- a/packs/deploy/actions/merge.yaml
+++ b/packs/deploy/actions/merge.yaml
@@ -1,0 +1,15 @@
+---
+name: merge
+runner_type: run-python
+description: Merge in action defaults with input from ChatOps
+enabled: true
+entry_point: merge.py
+parameters:
+  defaults:
+    type: object
+    description: "Dictionary of default values"
+    required: true
+  overrides:
+    type: object
+    description: "Dictionary of override values"
+    required: true

--- a/packs/deploy/actions/pack.rb
+++ b/packs/deploy/actions/pack.rb
@@ -1,0 +1,303 @@
+#!/usr/bin/env ruby
+##
+## StackStorm Pack Branch Deployment Script
+##
+## This script is designed to allow branch deployments
+## of packs, from a variety of upstream sources.
+##
+require 'fileutils'
+require 'optparse'
+require 'json'
+require 'socket'
+
+module Deploy
+  class Pack
+    E_GENERICERROR=127
+    attr_reader :repo, :pack, :branch, :subtree, :basedir, :options, :command, :first_run
+
+    def initialize(options)
+      @repo = options[:repo]
+      @pack = options[:pack]
+      @branch = options[:branch]
+      @basedir = options[:basedir]
+      @options = options
+      @first_run = Dir.exists?(pack_dir) ? false : true
+
+      setup
+      eval_command(options)
+      eval_subtree(options)
+
+      debug "[#initialize] Repo: #{repo}, Pack: #{pack}, Ref: #{branch}, Subtree: #{subtree}"
+    end
+
+    def eval_command(options)
+      @command = if options[:info] && !options[:delete]
+        :info
+      elsif options[:delete] && !options[:info]
+        :delete
+      else
+        :run
+      end
+    end
+
+    def eval_subtree(options)
+      if state.has_key?('subtree')
+        @subtree = state['subtree']
+      else
+        # Try and do the user a favor, and automatically compute subtree if it wasn't
+        # explicitly set. This is to account for the packs that are in a monolithic repo
+        # and need to be pulled out. Specifically, st2contrib and st2incubator
+        match = repo.index(/[sS]tack[sS]torm\/st2/) ? true : false
+
+        # XOR match to user input and match parameters
+        @subtree = match ^ options[:subtree]
+        state['subtree'] = @subtree
+      end
+      debug "[#eval_subtree] Subtree: #{subtree}, state: #{state['subtree']}"
+    end
+
+    def setup
+      [vcs_dir, packs_dir].each do |d|
+        unless Dir.exists?(d)
+          debug "[#setup] Creating directory #{d}"
+          FileUtils.mkdir_p(d)
+        end
+      end
+    end
+
+    def cmds_available?(cmds)
+      Array(cmds).each do |cmd|
+        exist = `sh -c 'command -v #{cmd}'`.size.>(0)
+        unless exist
+          bail("command missing: #{cmd}")
+        end
+      end
+    end
+
+    def bail(message, code=E_GENERICERROR)
+      log message
+      exit code
+    end
+
+    def packs_dir
+      File.join(basedir, 'packs')
+    end
+
+    def pack_dir
+      File.join(packs_dir, pack)
+    end
+
+    def vcs_dir
+      File.join(basedir, 'vcs')
+    end
+
+    def vcs_file
+      File.join(pack_dir, '.vcs')
+    end
+
+    def pack_vcs_dir
+      File.join(vcs_dir, pack)
+    end
+
+    def pack_vcs_dir_exists?
+      File.directory? pack_vcs_dir
+    end
+
+    def clone_pack
+      options[:first_clone] = true
+      exec "git clone #{repo} #{pack_vcs_dir}"
+      state['upstream'] = repo
+    end
+
+    def checkout_branch
+      Dir.chdir pack_vcs_dir
+      exec 'git fetch --all'
+      exec "git reset --hard origin/#{branch}"
+      state['branch'] = branch
+      state['ref'] = `git rev-list -1 HEAD`.chomp
+    end
+
+    def sync_pack(args={})
+      dry_opts = args[:dry_run] ? '--dry-run' : nil
+      src_dir = subtree ? File.join(pack_vcs_dir, 'packs', pack) : pack_vcs_dir
+      debug "[#sync_pack] subtree: #{subtree} src_dir: #{src_dir}"
+      cmd = ['rsync', '-avz', dry_opts, '--delete',
+             '--exclude=.git', '--exclude=config.txt', '--exclude=.vcs',
+             src_dir, packs_dir
+      ]
+
+      exec cmd.join(' ')
+    end
+
+    def save_state
+      File.open(vcs_file, 'w') { |f| f.write(state.to_json) }
+    end
+
+    def state
+      begin
+        @state ||= File.open(vcs_file, 'r') { |f| JSON.load(f) }
+      rescue
+        @state ||= {'branch' => nil, 'ref' => nil}
+      end
+    end
+
+    def reload_st2
+      exec 'st2ctl reload --register-all'
+    end
+
+    def log(message, extra={})
+      puts "{#{Socket.gethostname}} #{message}"
+    end
+
+    def exec(cmd)
+      debug "[exec] Running: #{cmd}"
+      debug `#{cmd}`
+    end
+
+    def debug(message)
+      puts message if options[:debug]
+      return message
+    end
+
+    def dirty_tree?
+      Dir.chdir pack_vcs_dir
+      `git status -s 2> /dev/null`.size.>(0) ? true : false
+    end
+
+    def current_branch
+      Dir.chdir pack_vcs_dir
+      return "branch: #{state['branch']}, ref: #{state['ref']}, upstream: #{state['upstream']}"
+    end
+
+    def branch_exists?
+      Dir.chdir pack_vcs_dir
+      `git ls-remote --heads`.include?(branch)
+    end
+
+    # Determine if the running directory is in sync with the vcs repository.
+    # Used in the event some editing has happened in the pack directly
+    def nsync?
+      sync = sync_pack(:dry_run => true)
+      sync =~ /#{pack_vcs_dir}/ ? false : true
+    end
+
+    ### Control Functions
+    def cmd_info
+      cmds_available? ['git', 'rsync']
+      if nsync? && !dirty_tree?
+        log "in-sync and clean. #{current_branch}"
+      elsif dirty_tree?
+        log "Dirty git tree! Take a look at #{pack_vcs_dir}. #{current_branch}"
+      end
+    end
+
+    def cmd_run
+      cmds_available? ['git', 'rsync', 'st2ctl']
+
+      clone_pack unless pack_vcs_dir_exists?
+
+      if !dirty_tree? && branch_exists?
+        checkout_branch
+      elsif !branch_exists?
+        bail "Git branch does not exist upstream. #{branch}"
+      elsif dirty_tree?
+        bail "Git tree is dirty. Will not proceed until reviewed in #{pack_vcs_dir}"
+      end
+
+      if nsync?
+        sync_pack
+      else
+        bail "Hand-edited files exist in #{packs_dir}. Check on them and then re-run"
+      end
+
+      save_state
+      reload_st2
+      cmd_info
+    end
+
+    def cmd_delete
+      if pack_vcs_dir_exists? && options[:force]
+        [pack_dir, pack_vcs_dir].each do |dir|
+          debug "[cmd_delete] #{FileUtils.rm_rf(dir)}"
+        end
+        log 'OK'
+      else
+        bail 'Must use "force" if you really mean this'
+      end
+    end
+
+    ### CLI Runner
+    def self.run(options)
+      i = self.new(options)
+      i.send("cmd_#{i.command.to_s}")
+    end
+  end
+end
+
+# Shell Application Scaffolding
+options = Hash.new
+optparse = OptionParser.new do |opts|
+  options[:info] = false
+  opts.on('-i', '--info', 'Gather info on pack deployment (version, clean)') do
+    options[:info] = true
+  end
+
+  options[:pack] = nil
+  opts.on('-p', '--pack PACK', 'Pack to install/manage') do |pack|
+    options[:pack] = pack
+  end
+
+  options[:branch] = 'master'
+  opts.on('-r', '--branch BRANCH', 'Git branch to switch pack to') do |branch|
+    options[:branch] = branch
+  end
+
+  options[:repo] = 'https://github.com/StackStorm/st2contrib'
+  opts.on('-u', '--repo REPO', 'Git repositiory to clone pack from') do |repo|
+    options[:repo] = repo
+  end
+
+  options[:basedir] = '/opt/stackstorm'
+  opts.on('-b', '--basedir DIR', 'Base directory where StackStorm packs are installed') do |basedir|
+    options[:basedir] = basedir
+  end
+
+  options[:subtree] = false
+  opts.on('-s', '--subtree', 'Pack is installed in subtree packs/$PACK of repo') do
+    options[:subtree] = true
+  end
+
+  options[:force] = false
+  opts.on('-f', '--force', 'Force destructive actions') do
+    options[:force] = true
+  end
+
+  options[:delete] = false
+  opts.on('-x', '--delete', 'Delete installation of a pack') do
+    options[:delete] = true
+  end
+
+  options[:debug] = false
+  opts.on('-d', '--debug', 'Enable debug output') do
+    options[:debug] = true
+  end
+
+  opts.on('-h', '--help', 'Display this screen') { puts opts; exit }
+end
+
+begin
+  optparse.parse!
+  mandatory = [:pack, :repo, :basedir]
+  missing = mandatory.select{ |param| options[param].nil? }
+  unless missing.empty?
+    puts "Missing options: #{missing.join(', ')}"
+    puts optparse
+    exit
+  end
+rescue OptionParser::InvalidOption, OptionParser::MissingArgument
+  puts $!.to_s
+  puts optparse
+  exit
+end
+
+Deploy::Pack.run(options)

--- a/packs/deploy/actions/pack.yaml
+++ b/packs/deploy/actions/pack.yaml
@@ -1,0 +1,36 @@
+---
+name: pack
+runner_type: run-remote-script
+description: Action to perform pack deployments via Git branch deploys
+enabled: true
+entry_point: pack.rb
+parameters:
+  pack:
+    type: string
+    description: Name of the pack to be deployed
+    required: true
+  repo:
+    type: string
+    description: Location where to retrieve remote pack from
+    required: true
+  subtree:
+    type: boolean
+    description: Flag to determine whether pack is nested within a repository, or is stand-alone
+  branch:
+    type: string
+    description: git branch to deploy
+    default: 'origin/master'
+  info:
+    type: boolean
+    description: Get information about deployed pack
+  debug:
+    type: boolean
+    description: Provide additional debug informat
+  delete:
+    type: boolean
+    description: Delete a pack
+  force:
+    type: boolean
+    description: Force a destructive action
+  sudo:
+    default: true

--- a/packs/deploy/actions/pack_chatops.yaml
+++ b/packs/deploy/actions/pack_chatops.yaml
@@ -1,0 +1,15 @@
+---
+name: pack.chatops
+runner_type: action-chain
+description: Action to perform pack deployments via ChatOps
+enabled: true
+entry_point: 'workflows/pack_chatops.yaml'
+parameters:
+  message:
+    type: string
+    description: Message sent via ChatOps
+    required: true
+  channel:
+    type: string
+    description: Channel to emit events to
+    required: true

--- a/packs/deploy/actions/parse_pack_chatops.rb
+++ b/packs/deploy/actions/parse_pack_chatops.rb
@@ -1,0 +1,72 @@
+#!/usr/bin/env ruby
+
+require 'rubygems'
+require 'uri'
+require 'json'
+
+message = ARGV
+commands   = []
+parameters = {}
+defaults   = {
+  'branch'     => 'master',
+  'subtree'    => true,
+  'role'       => 'localhost',
+  'debug'      => false,
+  'info'       => false,
+  'delete'     => false,
+  'force'      => false,
+}
+
+# Break up the message into commands vs parameters
+message.each do |w|
+  if w =~ /=/
+    p = w.split('=')
+    parameters[p[0]] = p[1].gsub(/['"]/, '')
+  else
+    # Only collect commands before parameters are entered.
+    # It's garbage otherwise
+    commands << w if parameters.empty?
+  end
+end
+
+# Make sure this is a pack deployment
+unless commands.include?('pack')
+  puts "This is not a pack deployment command."
+  exit 1
+end
+
+# Let's now see if we can suss out what the user wants.
+# Should address a few uses...
+#   Use 1: !deploy pack rackspace from StackStorm/st2incubator
+#   - pack: rackspace, repo: https://github.com/StackStorm/st2incubator, subtree = true
+#   Use 2: !deploy pack StackStorm/rackspace
+#   - pack: rackspace, repo: https://github.com/StackStorm/rackspace, subtree = false
+#   Use 3: !deploy pack https://bitbucket.com/StackStorm/rackspace
+#   - pack: rackspace, repo: https://bitbucket.com/StackStorm/rackspace
+
+# Grab the pack
+parameters['pack'] = commands[2].include?('/') ? commands[2].split('/')[1] : commands[2]
+
+# Determine array index for repo target
+irepo = commands.include?('from') ? 4 : 2
+
+case commands[irepo]
+# Let's also make sure that the repo target is what we expect (org/repo)
+when /^\w+\/\w+$/
+  parameters['repo'] = 'https://github.com/' + commands[irepo]
+# or is a valid URI target
+when URI::regexp
+  parameters['repo'] = commands[irepo]
+else
+  parameters['repo'] = 'https://github.com/StackStorm/st2contrib'
+end
+
+# And toggle off tree traversal if standalone repo
+parameters['subtree'] = false if irepo == 2
+
+payload = {
+  'commands'   => commands,
+  'parameters' => defaults.merge(parameters),
+}
+
+puts payload.to_json

--- a/packs/deploy/actions/parse_pack_chatops.yaml
+++ b/packs/deploy/actions/parse_pack_chatops.yaml
@@ -1,0 +1,12 @@
+---
+name: parse.pack.chatops
+runner_type: run-local-script
+description: ChatOps parser converting input to usable object for workflow
+enabled: true
+entry_point: parse_pack_chatops.rb
+parameters:
+  message:
+    type: string
+    description: "Input from ChatOps to be parsed"
+    position: 1
+    required: true

--- a/packs/deploy/actions/workflows/app.yaml
+++ b/packs/deploy/actions/workflows/app.yaml
@@ -1,0 +1,23 @@
+---
+name: deploy.app
+version: "2.0"
+
+workflows:
+  main:
+    description: "Deploy application via git to server(s)"
+    type: direct
+    input:
+      - app
+      - source
+      - path
+      - role
+      - branch
+      - post_deploy
+    task-defaults:
+      on-error:
+        - fail
+    tasks:
+      chatops_echo:
+        action: core.local
+        input:
+          command: "Deploying <% $.app %> from <% $.source %> to <% $.role %>:<% $.path %> with branch <% $.branch %>, running <% $.post_deploy %>"

--- a/packs/deploy/actions/workflows/pack_chatops.mistral.yaml
+++ b/packs/deploy/actions/workflows/pack_chatops.mistral.yaml
@@ -1,0 +1,83 @@
+---
+name: deploy.pack.chatops
+version: "2.0"
+
+workflows:
+  main:
+    description: "Main workflow to deploy packs via ChatOps"
+    type: direct
+    input:
+      - message
+      - channel
+    task-defaults:
+      on-error:
+        - fail
+    tasks:
+      parse_chatops_message:
+        action: deploy.parse.pack.chatops
+        input:
+          message: <% $.message %>
+        publish:
+          chatops_command: <% $.parse_chatops_message.result.command %>
+          chatops_parameters: <% $.parse_chatops_message.result.parameters %>
+        on-success:
+          - determine_if_locked
+      determine_if_locked:
+        action: st2.kv.get
+        input:
+          key: 'deploy.pack.<% $.parameters.pack %>.locked'
+        publish:
+          locked_by: <% $.determine_if_locked.result %>
+        on-success:
+          - fail_locked
+        on-error:
+          - notify_deploy
+      fail_locked:
+        action: slack.post_message
+        input:
+          message: '```Deploy of pack <% $.pack %> locked by <% $.locked_by %>. Go bug that person!```'
+          channel: <% $.channel %>
+      notify_deploy:
+        action: slack.post_message
+        input:
+          message: '```Deploying pack <% $.pack %> branch=<% $.branch %>```'
+          channel: <% $.channel %>
+        on-success:
+          - retrieve_st2_hosts
+      retrieve_st2_hosts:
+        action: core.local
+        input:
+          cmd: 'echo noop'
+        publish:
+          st2_servers:
+            - localhost
+        on-success:
+          - kickoff_deploy
+      kickoff_deploy:
+        action: deploy.pack
+        with-items: i in <% $.st2_servers %>
+        input:
+          pack: <% $.pack %>
+          repo: <% $.repo %>
+          subtree: <% $.subtree %>
+          branch: <% $.branch %>
+          info: <% $.info %>
+          debug: <% $.debug %>
+          delete: <% $.delete %>
+          force: <% $.force %>
+        publish:
+          deploy_output: <% $.kickoff_deploy.result.stdout %>
+        on-success:
+          - notify_success
+        on-error:
+          - notify_failure
+      notify_success:
+        action: slack.post_message
+        input:
+          message: '```<% $.deploy_output %>```'
+          channel: <% $.channel %>
+      notify_failure:
+        action: slack.post_message
+        input:
+          message: '```Failure deploying pack <% $.pack %>. Check history for details.```'
+          channel: <% $.channel %>

--- a/packs/deploy/actions/workflows/pack_chatops.yaml
+++ b/packs/deploy/actions/workflows/pack_chatops.yaml
@@ -1,0 +1,57 @@
+---
+  chain:
+    -
+      name: parse
+      ref: deploy.parse.pack.chatops
+      params:
+        message: "{{message}}"
+      publish:
+        pack: "{{parse.stdout.parameters.pack}}"
+        repo: "{{parse.stdout.parameters.repo}}"
+        subtree: "{{parse.stdout.parameters.subtree}}"
+        branch: "{{parse.stdout.parameters.branch}}"
+        role: "{{parse.stdout.parameters.role}}"
+        info: "{{parse.stdout.parameters.info}}"
+        debug: "{{parse.stdout.parameters.debug}}"
+        delete: "{{parse.stdout.parameters.delete}}"
+        force: "{{parse.stdout.parameters.force}}"
+      on-success: lookup_hosts_to_execute
+    -
+      name: lookup_hosts_to_execute
+      ref: core.local
+      params:
+        cmd: 'echo noop'
+      publish:
+        st2_servers: localhost
+      on-success: notify_deploy
+    -
+      name: notify_deploy
+      ref: slack.post_message
+      params:
+        message: "```Deploying pack {{pack}} branch={{branch}}```"
+        channel: "{{channel}}"
+      on-success:
+        kickoff_deploy
+    -
+      name: kickoff_deploy
+      ref: deploy.pack
+      params:
+        pack: "{{pack}}"
+        repo: "{{repo}}"
+        subtree: "{{subtree}}"
+        branch: "{{branch}}"
+        info: "{{info}}"
+        debug: "{{debug}}"
+        delete: "{{delete}}"
+        force: "{{force}}"
+        hosts: "{{st2_servers}}"
+      publish:
+        deploy_output: "{{kickoff_deploy.localhost.stdout}}"
+      on-success: post_results
+      on-error: post_results
+    -
+      name: post_results
+      ref: slack.post_message
+      params:
+        message: "```{{deploy_output}}```"
+        channel: "{{channel}}"

--- a/packs/deploy/config.yaml
+++ b/packs/deploy/config.yaml
@@ -1,0 +1,3 @@
+### Place configuration data for your pack here.
+---
+

--- a/packs/deploy/pack.yaml
+++ b/packs/deploy/pack.yaml
@@ -1,0 +1,8 @@
+### Place information about your pack version here.
+---
+name: deploy
+description: deploy
+version: 0.0.1
+author: jfryman
+email: jfryman@FryBook
+

--- a/packs/deploy/rules/README.md
+++ b/packs/deploy/rules/README.md
@@ -1,0 +1,3 @@
+# rules
+
+The rules folder contains rules. See [Rules](http://docs.stackstorm.com/rules.html) for specifics on writing rules.

--- a/packs/deploy/rules/deploy_pack_chatops.yaml
+++ b/packs/deploy/rules/deploy_pack_chatops.yaml
@@ -1,0 +1,15 @@
+---
+  name: 'deploy.pack.chatops'
+  description: 'Manage StackStorm Pack Deployment via ChatOps'
+  enabled: true
+  trigger:
+    type: 'slack.message'
+  criteria:
+    trigger.text:
+      type: startswith
+      pattern: '!deploy pack'
+  action:
+    ref: deploy.pack.chatops
+    parameters:
+      message: "{{trigger.text}}"
+      channel: "#{{trigger.channel.name}}"

--- a/packs/deploy/sensors/README.md
+++ b/packs/deploy/sensors/README.md
@@ -1,0 +1,4 @@
+# sensors
+
+The sensors folder contains sensoros. See [Sensors](http://docs.stackstorm.com/sensors.html) for specifics on writing
+sensors and registering TriggerTypes.


### PR DESCRIPTION
Alright, I was really hoping to wait until we finish ChatOps before I start introducing commands into our lexicon, but this one seemed too important to wait, and will also give us something to throw darts at as we go down our voyage. I also said I would do this last week, but other things ate my time. So, here's a bit of weekend hacking!

## Pack Deployment

This PR introduces the ability to do rapid pack deployments on a StackStorm server via ChatOps. Very first pass, but I believe this to be the first beachhead... the speed at which we can do pack development is a bottleneck in both communication and flexibly. Unlocking this :zap: is essential to really start :racehorse:!

### Commands:

```
Usage: pack [options]
    -i, --info INFO                  Gather info on pack deployment (version, clean)
    -p, --pack PACK                  Pack to install/manage
    -r, --branch BRANCH              Git branch to switch pack to
    -u, --repo REPO                  Git repositiory to clone pack from
    -b, --basedir DIR                Base directory where StackStorm packs are installed
    -s, --subtree                    Pack is installed in subtree packs/$PACK of repo
    -f, --force                      Force destructive actions
    -x, --delete                     Delete installation of a pack
    -d, --debug                      Enable debug output
    -h, --help                       Display this screen
```

* Download a new pack. Tons of ways! (Note: Subtree is for nested packs versus standalone packs)
```
#   Use 1: !deploy pack rackspace from StackStorm/st2incubator
#   - pack: rackspace, repo: https://github.com/StackStorm/st2incubator, subtree = true
#   Use 2: !deploy pack StackStorm/rackspace
#   - pack: rackspace, repo: https://github.com/StackStorm/rackspace, subtree = false
#   Use 3: !deploy pack https://bitbucket.com/StackStorm/rackspace
#   - pack: rackspace, repo: https://bitbucket.com/StackStorm/rackspace
```

![slack](https://cloud.githubusercontent.com/assets/20028/6658335/3a50f972-cb34-11e4-8253-48d33782c2a4.png)


* Branch Deploys: Deploy specific branches of code

![slack](https://cloud.githubusercontent.com/assets/20028/6658384/8cae676c-cb35-11e4-9659-7a9bbc8d3e28.png)

* Get information on a deployed pack

![slack](https://cloud.githubusercontent.com/assets/20028/6658351/9d6054d6-cb34-11e4-999d-13dafb4d0005.png)

* Delete a pack installed on a system (NOTE: Must use `force=true`, as a bug exists that prevent a good error)

![slack](https://cloud.githubusercontent.com/assets/20028/6658370/283e06f2-cb35-11e4-85b1-5f3381be0829.png)

### Safety Features
* Will not deploy over manual changes on a system (don't do this, but it won't :fire::skull::fire: you)
* Will only deploy branches that exist



### Limitations

* This is not intended to be the end-game for Pack Deployments via ChatOps. Instead, this is first :hammer: stuff. Several reasons: 
  * Written in Ruby (for the :laughing: , as well as to demonstrate it could be done (/cc @dzimine))
  * Specific to Slack for Chat
  * Might have specific CMDB mechanism for StackStorm in the short term
  * Command overload. The namespace for this command is odd, and the interface is equally so. Will change before GA
* Mapping between help and actual commands output by help is mismatched. Maybe a bit confusing, it'll get fixed.
* Currently no locking mechanism. I started to model this in mistral, and then decided to :football: and go eat. For now, this will do, but it could be that we need to introduce locking sooner than later. Let's see how it plays out.
* Self-Server. Right now, this only manages deployments on a single node. This should be easily fixable, but want to confer with @DoriftoShoes on how we actually do things internally. ActionChain facilitates the single runner, and we might be able to get tricky by overloading `hosts`, but more thought needs to go here.
* No Access Control. Deleting a pack could happen, so be careful.
* Errors in processing prevent all error messages from being thrown properly.

### More to do
* Add locking mechanism
* Auto-deploy on branch deploy
* Auto-unlock on merge-to-master