### PR TITLE
Tag on deploy pass

### DIFF
--- a/packs/st2cd/actions/create_version_tag_rule.py
+++ b/packs/st2cd/actions/create_version_tag_rule.py
@@ -1,0 +1,101 @@
+#! /usr/bin/env python
+
+import argparse
+import json
+import requests
+import sys
+
+
+def create_rule(url, rule):
+    # check if rule with the same name exists
+    existing_rule_id = _get_rule_id(url, rule)
+
+    headers = {'created-from': 'Action: ' + __name__}
+    # TODO: Figure out AUTH
+    if existing_rule_id:
+        sys.stderr.write('Updating existing rule %s\n' % existing_rule_id)
+        put_url = '%s/%s' % (url, existing_rule_id)
+        rule['id'] = existing_rule_id
+        resp = requests.put(put_url, data=json.dumps(rule), headers=headers)
+    else:
+        sys.stderr.write('Creating new rule %s\n' % rule['name'])
+        sys.stderr.write('url=%s, data=%s' % (url, json.dumps(rule)))
+        resp = requests.post(url, data=json.dumps(rule), headers=headers)
+
+    if resp.status_code not in [200, 201]:
+        raise Exception('Failed creating rule in st2. status code: %s' % resp.status_code)
+
+
+def _get_rule_id(base_url, rule):
+    get_url = '%s/?name=%s' % (base_url, rule['name'])
+    sys.stderr.write(get_url)
+    resp = requests.get(get_url)
+    if resp.status_code in [200]:
+        if len(resp.json()) > 0:
+            return resp.json()[0]['id']
+    return None
+
+
+def _get_st2_rules_url(base_url):
+    if base_url.endswith('/'):
+        return base_url + 'rules'
+    else:
+        return base_url + '/rules'
+
+
+def main(args):
+    parser = argparse.ArgumentParser(description='Create a rule to that watches ' +
+                                                 'for github events on a branch.')
+    parser.add_argument('--branch', help='Branch to use.',
+                        required=True)
+    parser.add_argument('--st2-base-url', help='st2 base url.',
+                        required=True)
+    args = parser.parse_args()
+
+    if args.branch in ['master']:
+        sys.stderr.write('Master is not allowed branch for release.')
+        sys.exit(1)
+
+    if not args.st2_base_url:
+        sys.stderr.write('st2 URL needed to create a rule.')
+        sys.exit(2)
+
+    rule_meta = {
+        'name': 'st2_tag_release_' + args.branch,
+        'description': 'Tag branch on build completion.',
+        'enabled': True,
+        'trigger': {
+            'type': 'core.st2.generic.actiontrigger'
+        },
+        'criteria': {
+            'trigger.action_name': {
+                'pattern': 'st2cd.st2_packaging',
+                'type': 'equals'
+            },
+            'trigger.parameters.branch': {
+                'pattern': args.branch,
+                'type': 'equals'
+            },
+            'trigger.parameters.environment': {
+                'pattern': 'production',
+                'type': 'equals'
+            }
+        },
+        'action': {
+            'ref': 'st2cd.st2_finalize_release',
+            'parameters': {
+                'branch': args.branch
+            }
+        }
+    }
+
+    try:
+        create_rule(_get_st2_rules_url(args.st2_base_url), rule_meta)
+        sys.stdout.write('Successfully created rule %s\n' % rule_meta['name'])
+    except Exception as e:
+        sys.stderr.write('Failed creating rule %s: %s\n' % (rule_meta['name'], str(e)))
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/packs/st2cd/actions/create_version_tag_rule.yaml
+++ b/packs/st2cd/actions/create_version_tag_rule.yaml
@@ -1,0 +1,20 @@
+---
+  name: "create_version_tag_rule"
+  runner_type: "run-remote-script"
+  description: "Create a rule to listen for package builds on a release branch."
+  enabled: true
+  entry_point: "create_version_tag_rule.py"
+  parameters:
+    st2-base-url:
+      type: "string"
+      description: "St2 base url."
+      default: "http://localhost:9101/v1/"
+    branch:
+      type: "string"
+      description: "Github branch to setup the rule on."
+    kwarg_op:
+      immutable: true
+      default: "--"
+    sudo:
+      immutable: true
+      default: false

--- a/packs/st2cd/actions/git_branch.sh
+++ b/packs/st2cd/actions/git_branch.sh
@@ -5,17 +5,18 @@ REPO=$1
 DATE=`date +%s`
 VERSION=$2
 BRANCH=$3
+BASE_BRANCH=$4
 FILE="st2common/st2common/__init__.py"
 OUTPUT=/tmp/git-output-$DATE
 
 cd ${REPO}
-OUT=`$GIT pull origin master -q > $OUTPUT && $GIT branch ${BRANCH} -q && $GIT checkout ${BRANCH} -q`
+OUT=`$GIT checkout ${BASE_BRANCH} -q > $OUTPUT && $GIT pull origin ${BASE_BRANCH} -q > $OUTPUT && $GIT checkout -b ${BRANCH} -q`
 if [[ $? == 0 ]]
 then
   VERSIONOUT=`sed -i -e "s/\(__version__ = \).*/\1'${VERSION}'/" ${FILE}`
   if [[ $? == 0 ]]
   then
-    OUT=`$GIT add $FILE && $GIT commit -aqm "Cutting branch for release - ${VERSION}" && $GIT push origin -q $BRANCH`
+    OUT=`$GIT add $FILE > $OUTPUT && $GIT commit -aqm "Cutting branch for release - ${VERSION}" > $OUTPUT && $GIT push origin $BRANCH -q > $OUTPUT`
     if [[ $? == 0 ]]
     then
       echo ${BRANCH}

--- a/packs/st2cd/actions/git_branch.yaml
+++ b/packs/st2cd/actions/git_branch.yaml
@@ -23,6 +23,11 @@
       required: true
       position: 2
       default: "v{{version}}"
+    base_branch:
+      type: "string"
+      description: "Branch name to use as base."
+      position: 3
+      default: "master"
     sudo:
       immutable: true
       default: false

--- a/packs/st2cd/actions/git_branch_remove.sh
+++ b/packs/st2cd/actions/git_branch_remove.sh
@@ -7,20 +7,14 @@ BRANCH=$2
 OUTPUT=/tmp/git-output-$DATE
 
 cd ${REPO}
-OUT=`$GIT pull origin master -q > $OUTPUT && $GIT checkout ${BRANCH} -q`
+
+# There could be a tag with the same name so use complete path.
+OUT=`$GIT push origin :refs/heads/$BRANCH  > ${OUTPUT}`
 if [[ $? == 0 ]]
 then
-  OUT=`$GIT push origin -q :$BRANCH`
-  if [[ $? == 0 ]]
-  then
-    echo ${BRANCH}
-  else
-    cat ${OUTPUT}
-    rm ${OUTPUT}
-    exit 1
-  fi
+  echo ${BRANCH}
 else
   cat ${OUTPUT}
   rm ${OUTPUT}
-  exit 2
+  exit 1
 fi

--- a/packs/st2cd/actions/git_branch_remove.sh
+++ b/packs/st2cd/actions/git_branch_remove.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+GIT=`which git`
+REPO=$1
+DATE=`date +%s`
+BRANCH=$2
+OUTPUT=/tmp/git-output-$DATE
+
+cd ${REPO}
+OUT=`$GIT pull origin master -q > $OUTPUT && $GIT checkout ${BRANCH} -q`
+if [[ $? == 0 ]]
+then
+  OUT=`$GIT push origin -q :$BRANCH`
+  if [[ $? == 0 ]]
+  then
+    echo ${BRANCH}
+  else
+    cat ${OUTPUT}
+    rm ${OUTPUT}
+    exit 1
+  fi
+else
+  cat ${OUTPUT}
+  rm ${OUTPUT}
+  exit 2
+fi

--- a/packs/st2cd/actions/git_branch_remove.yaml
+++ b/packs/st2cd/actions/git_branch_remove.yaml
@@ -1,0 +1,31 @@
+---
+  name: "git_branch_remove"
+  runner_type: "run-remote-script"
+  description: "Remove branch from repo and push to remote."
+  enabled: true
+  entry_point: "git_branch_remove.sh"
+  parameters:
+    repo:
+      type: "string"
+      description: "Location of st2 cloned git repo on disk."
+      required: true
+      position: 0
+      default: "/home/stanley/st2/"
+    branch:
+      type: "string"
+      description: "Branch name to use. Example: v${version_number}."
+      required: true
+      position: 1
+      default: "release"
+    dir:
+      immutable: true
+      default: "/home/stanley/"
+    sudo:
+      immutable: true
+      default: false
+    cmd:
+      immutable: true
+      default: ""
+    kwarg_op:
+      immutable: true
+      default: "--"

--- a/packs/st2cd/actions/st2_finalize_release.meta.yaml
+++ b/packs/st2cd/actions/st2_finalize_release.meta.yaml
@@ -1,0 +1,19 @@
+---
+  name: "st2_finalize_release"
+  runner_type: "action-chain"
+  description: "Look at workflows/st2_finalize_release.yaml"
+  enabled: true
+  entry_point: "workflows/st2_finalize_release.yaml"
+  parameters:
+    st2_repo:
+      type: "string"
+      description: "Url of the st2 repo to clone"
+      default: "https://github.com/StackStorm/st2.git"
+    st2_repo_target:
+      type: "string"
+      default: "/home/stanley/st2"
+      description: "Path to clone st2 repo to."
+    branch:
+      type: "string"
+      description: "st2 branch to tag."
+      required: true

--- a/packs/st2cd/actions/tag_branch.sh
+++ b/packs/st2cd/actions/tag_branch.sh
@@ -11,7 +11,7 @@ OUT=`$GIT checkout ${BRANCH} -q && $GIT pull origin ${BRANCH} -q > ${OUTPUT}`
 if [[ $? == 0 ]]
 then
   # pick version from st2common and use that to generate tag value
-  BRANCHVERSION = `grep version st2common/st2common/__init__.py | awk '{print $3}' | tr -d "'"`
+  BRANCHVERSION=`grep version st2common/st2common/__init__.py | awk '{print $3}' | tr -d "'"`
   NEWTAG=v${BRANCHVERSION}
   if [[ $? == 0 ]]
   then

--- a/packs/st2cd/actions/tag_branch.sh
+++ b/packs/st2cd/actions/tag_branch.sh
@@ -10,7 +10,9 @@ cd ${REPO}
 OUT=`$GIT checkout ${BRANCH} -q && $GIT pull origin ${BRANCH} -q > ${OUTPUT}`
 if [[ $? == 0 ]]
 then
-  NEWTAG=`git describe --tags --abbrev=0 | awk -F '[ .]' '{print $1"."$2"."$3+1}'`
+  # pick version from st2common and use that to generate tag value
+  BRANCHVERSION = `grep version st2common/st2common/__init__.py | awk '{print $3}' | tr -d "'"`
+  NEWTAG=v${BRANCHVERSION}
   if [[ $? == 0 ]]
   then
     OUT=`$GIT tag -a ${NEWTAG} -m "Creating tag ${NEWTAG} for branch ${BRANCH}" && $GIT push origin ${NEWTAG} -q`

--- a/packs/st2cd/actions/workflows/st2_finalize_release.yaml
+++ b/packs/st2cd/actions/workflows/st2_finalize_release.yaml
@@ -1,0 +1,98 @@
+---
+  chain:
+    -
+      name: "get_build_server"
+      ref: "linux.dig"
+      params:
+        hostname: "st2build.service.consul"
+        rand: true
+        count: 1
+      publish:
+        build_server: "{{get_build_server.result[0]}}"
+      on-success: "clone_repo"
+      on-failure: "slack_failure"
+    -
+      name: "clone_repo"
+      ref: "st2cd.git_clone"
+      params:
+        hosts: "{{build_server}}"
+        repo: "{{st2_repo}}"
+        branch: "{{branch}}"
+        target: "{{st2_repo_target}}"
+      publish:
+        repo: "{{clone_repo[build_server].stdout}}"
+      on-success: "tag_st2_branch"
+      on-failure: "clean_repo_failure"
+    -
+      name: "tag_st2_branch"
+      ref: "st2cd.tag_branch"
+      params:
+        hosts: "{{build_server}}"
+        repo: "{{repo}}"
+        branch: "{{branch}}"
+        timeout: 600
+      publish:
+        tagged_version: "{{tag_st2_branch[build_server].stdout | replace('v', '')}}"
+      on-success: "remove_patch_branch"
+      on-failure: "clean_repo_failure"
+    -
+      name: "remove_patch_branch"
+      ref: "st2cd.git_branch_remove"
+      params:
+        hosts: "{{build_server}}"
+        repo: "{{repo}}"
+        branch: "v{{tagged_version}}"
+        timeout: 600
+      on-success: "get_next_version"
+      on-failure: "clean_repo_failure"
+    -
+      name: "get_next_version"
+      ref: "core.local"
+      params:
+        cmd: "echo {{tagged_version}} | awk -F '[ .]' '{print $1\".\"$2\".\"$3+1}'"
+      publish:
+        next_version: "{{get_next_version.stdout | replace('\n', '')}}"
+      on-success: "create_next_patch_branch"
+      on-failure: "clean_repo_failure"
+    -
+      name: "create_next_patch_branch"
+      ref: "st2cd.git_branch"
+      params:
+        hosts: "{{build_server}}"
+        repo: "{{repo}}"
+        version: "{{next_version}}"
+        branch: "v{{next_version}}"
+        base_branch: "{{branch}}"
+        timeout: 600
+      on-success: "clean_repo_success"
+      on-failure: "clean_repo_failure"
+    -
+      name: "clean_repo_success"
+      ref: "st2cd.git_clean"
+      params:
+        hosts: "{{build_server}}"
+        repo: "{{repo}}"
+      on-success: "slack_success"
+      on-failure: "slack_failure"
+    -
+      name: "clean_repo_failure"
+      ref: "st2cd.git_clean"
+      params:
+        hosts: "{{build_server}}"
+        repo: "{{repo}}"
+      on-success: "slack_failure"
+      on-failure: "slack_failure"
+    -
+      name: "slack_success"
+      ref: "slack.post_message"
+      params:
+        channel: "#releasemgmt"
+        message: "```[FINALIZE_RELEASE]\n STATUS: SUCCESS\n VERSION: {{tagged_version}}```"
+    -
+      name: "slack_failure"
+      ref: "slack.post_message"
+      params:
+        channel: "#releasemgmt"
+        message: "```[FINALIZE_RELEASE]\n STATUS: FAILURE\n BRANCH: {{branch}}```"
+
+  default: "get_build_server"

--- a/packs/st2cd/actions/workflows/st2_pytests_setup.yaml
+++ b/packs/st2cd/actions/workflows/st2_pytests_setup.yaml
@@ -39,6 +39,14 @@
         hosts: "{{get_build_server.result[0]}}"
         st2-base-url: "{{st2_base_url}}"
         branch: "v{{st2_release_version}}"
+      on-success: "setup_tag_rule_for_branch"
+    -
+      name: "setup_tag_rule_for_branch"
+      ref: "st2cd.create_version_tag_rule"
+      params:
+        hosts: "{{get_build_server.result[0]}}"
+        st2-base-url: "{{st2_base_url}}"
+        branch: "v{{st2_release_version}}"
       on-success: "clone_st2_repo"
     -
       name: "clone_st2_repo"


### PR DESCRIPTION
* Create a rule to tag the release on packaging completion
* Create a workflow that performs the actual tagging and setups a new branch for the next patch release.

Testing
* Workflow tested on fork of st2.
* Rule creation itself tested but rule matching untested.