### PR TITLE
Lookup active staging host in kvstore by branch and distro

### DIFF
--- a/packs/st2cd/rules/st2_upgrade_staging_f20.yaml
+++ b/packs/st2cd/rules/st2_upgrade_staging_f20.yaml
@@ -19,7 +19,7 @@
         parameters:
             action: "core.local"
             action_params: "hostname"
-            hostname: "fedora-staging201"
+            hostname: "{% set host_key = ['st2_stage_', trigger.parameters.branch, '_F20']|join %}{{system[host_key]}}"
             repo: "{{trigger.parameters.repo}}"
             branch: "{{trigger.parameters.branch}}"
             revision: "{{trigger.parameters.revision}}"

--- a/packs/st2cd/rules/st2_upgrade_staging_ubuntu14.yaml
+++ b/packs/st2cd/rules/st2_upgrade_staging_ubuntu14.yaml
@@ -19,7 +19,7 @@
         parameters:
             action: "core.local"
             action_params: "hostname"
-            hostname: "{{system.st2_ci_host}}"
+            hostname: "{% set host_key = ['st2_stage_', trigger.parameters.branch, '_UBUNTU14']|join %}{{system[host_key]}}"
             repo: "{{trigger.parameters.repo}}"
             branch: "{{trigger.parameters.branch}}"
             revision: "{{trigger.parameters.revision}}"


### PR DESCRIPTION
I need to move these to consul but this should get us up and running for running both 0.8 and master on a staging host.