### PR TITLE
Renamed integration_tests to e2e_tests and added new quickstart test

### DIFF
--- a/packs/st2cd/actions/st2_e2e_tests.meta.yaml
+++ b/packs/st2cd/actions/st2_e2e_tests.meta.yaml
@@ -1,9 +1,9 @@
 ---
-  name: "integration_tests"
+  name: "e2e_tests"
   runner_type: "action-chain"
-  description: "Runs a series of integration tests on a StackStorm server"
+  description: "Runs a series of end to end tests on a StackStorm server"
   enabled: true
-  entry_point: "workflows/st2_integration_tests.yaml"
+  entry_point: "workflows/st2_e2e_tests.yaml"
   parameters: 
     hostname: 
       type: "string"

--- a/packs/st2cd/actions/workflows/st2_deploy_test.yaml
+++ b/packs/st2cd/actions/workflows/st2_deploy_test.yaml
@@ -36,7 +36,7 @@
       on-success: "run_tests"
     -
       name: "run_tests"
-      ref: "st2cd.integration_tests"
+      ref: "st2cd.e2e_tests"
       params:
         hostname: "{{hostname}}"
         build: "0"

--- a/packs/st2cd/actions/workflows/st2_e2e_tests.yaml
+++ b/packs/st2cd/actions/workflows/st2_e2e_tests.yaml
@@ -1,6 +1,16 @@
 ---
   chain:
     -
+      name: "get_st2_token"
+      ref: "st2cd.get_st2_token"
+      params:
+        hosts: "{{hostname}}"
+        st2_username: "{{st2_username}}"
+        st2_password: "{{st2_password}}"
+      publish:
+        st2_token: "{{get_st2_token[hostname].stdout.token}}"
+      on-success: "install_tests"
+    -
       name: "install_tests"
       ref: "core.remote_sudo"
       params:

--- a/packs/st2cd/actions/workflows/st2_e2e_tests.yaml
+++ b/packs/st2cd/actions/workflows/st2_e2e_tests.yaml
@@ -1,14 +1,11 @@
 ---
   chain:
     -
-      name: "get_st2_token"
-      ref: "st2cd.get_st2_token"
+      name: "install_tests"
+      ref: "core.remote_sudo"
       params:
         hosts: "{{hostname}}"
-        st2_username: "{{st2_username}}"
-        st2_password: "{{st2_password}}"
-      publish:
-        st2_token: "{{get_st2_token[hostname].stdout.token}}"
+        cmd: "/usr/local/lib/python2.7/dist-packages/st2common/bin/st2-setup-tests"
       on-success: "core_local_date"
     -
       name: "core_local_date"
@@ -39,13 +36,14 @@
         action: "core.remote"
         params: "hosts={{hostname}} hostname"
         hosts: "{{hostname}}"
-#      on-success: "action_chain_load"
-#    -
-#      name: "action_chain_load"
-#      ref: "st2cd.action_run"
-#      params:
-#        name: "linux_diag_loadavg"
-#        action: "linux.diag_loadavg"
-#        params: "hostname={{hostname}}"
-#        hosts: "{{hostname}}"
+      on-success: "test_quickstart"
+    -
+      name: "test_quickstart"
+      ref: "st2cd.action_run"
+      params:
+        name: "test_quickstart"
+        token: "{{st2_token}}"
+        action: "tests.test_quickstart"
+        hosts: "{{hostname}}"
+
   default: "get_st2_token"

--- a/packs/st2cd/rules/st2_pkg_prod_master_f20.yaml
+++ b/packs/st2cd/rules/st2_pkg_prod_master_f20.yaml
@@ -6,7 +6,7 @@
         type: "core.st2.generic.actiontrigger"
     criteria:
         trigger.action_name:
-            pattern: "st2cd.integration_tests"
+            pattern: "st2cd.e2e_tests"
             type: "equals"
         trigger.status:
             pattern: "succeeded"

--- a/packs/st2cd/rules/st2_pkg_prod_master_ubuntu14.yaml
+++ b/packs/st2cd/rules/st2_pkg_prod_master_ubuntu14.yaml
@@ -6,7 +6,7 @@
         type: "core.st2.generic.actiontrigger"
     criteria:
         trigger.action_name:
-            pattern: "st2cd.integration_tests"
+            pattern: "st2cd.e2e_tests"
             type: "equals"
         trigger.status:
             pattern: "succeeded"

--- a/packs/st2cd/rules/st2_test_staging_f20.yaml
+++ b/packs/st2cd/rules/st2_test_staging_f20.yaml
@@ -15,7 +15,7 @@
             pattern: "staging"
             type: "equals"
     action:
-        ref: "st2cd.integration_tests"
+        ref: "st2cd.e2e_tests"
         parameters:
             hostname: "fedora-staging201"
             repo: "{{trigger.parameters.repo}}"

--- a/packs/st2cd/rules/st2_test_staging_ubuntu14.yaml
+++ b/packs/st2cd/rules/st2_test_staging_ubuntu14.yaml
@@ -15,7 +15,7 @@
             pattern: "staging"
             type: "equals"
     action:
-        ref: "st2cd.integration_tests"
+        ref: "st2cd.e2e_tests"
         parameters:
             hostname: "{{trigger.parameters.hostname}}"
             repo: "{{trigger.parameters.repo}}"

--- a/packs/st2cd/rules/st2cd_slack_e2e_test.yaml
+++ b/packs/st2cd/rules/st2cd_slack_e2e_test.yaml
@@ -1,12 +1,12 @@
 ---
-    name: "st2cd_slack_integration_test"
+    name: "st2cd_slack_e2e_test"
     description: "Post results of st2cd workflows to slack"
     enabled: true
     trigger:
         type: "core.st2.generic.actiontrigger"
     criteria:
         trigger.action_name:
-            pattern: "st2cd.integration_tests"
+            pattern: "st2cd.e2e_tests"
             type: "equals"
     action:
         ref: "slack.post_message"


### PR DESCRIPTION
This renamed the integration_tests workflow to e2e_tests, adds a step to install the tests pack, and adds the first quickstart test workflow.