### PR TITLE
Various autoscale fixes

### DIFF
--- a/packs/autoscale/README.md
+++ b/packs/autoscale/README.md
@@ -84,6 +84,10 @@ section includes a list of the used datastore items along with their purpose.
 
 ### Temporary Data
 
+* ``asg.<asg group name>.status`` (string) - Current status of the group (``idle/expanding/deflating``).
+  Internally this variable is used to prevent race conditions which can occur if the time between the
+  group creation and the initial expansion / deflation event is greater than ``delay`` minutes or if the
+  actual expansion / deflation process takes more than ``delay`` minutes.
 * ``asg.<asg group name>.total_nodes`` (int) - Current number of active nodes in this group.
 * ``asg.<asg group name>.last_expand_timestamp`` (int) - Timestamp when this group was last expanded.
 * ``asg.<asg group name>.last_deflate_timestamp`` (int) - Timestamp when this group was last deflated.

--- a/packs/autoscale/actions/asg_create.yaml
+++ b/packs/autoscale/actions/asg_create.yaml
@@ -44,7 +44,7 @@ parameters:
   expand_delay:
     type: integer
     description: Length of time (in minutes) between autoscale expansion events
-    default: 10
+    default: 20
   deflate_by:
     type: integer
     description: Number of nodes to deflate-by at a time during auto-scaling
@@ -61,6 +61,11 @@ parameters:
     type: string
     description: VM Size ID (use rackspace.list_vm_sizes to discover)
     default: '00a5dffd-1f9a-47a8-9ccc-7267a362a9da'
+  initial_status:
+    type: string
+    description: Initial auto scale group status
+    default: idle
+    immutable: true
   channel:
     type: string
     description: Slack channel to send ChatOps events

--- a/packs/autoscale/actions/asg_create.yaml
+++ b/packs/autoscale/actions/asg_create.yaml
@@ -44,7 +44,7 @@ parameters:
   expand_delay:
     type: integer
     description: Length of time (in minutes) between autoscale expansion events
-    default: 20
+    default: 10
   deflate_by:
     type: integer
     description: Number of nodes to deflate-by at a time during auto-scaling

--- a/packs/autoscale/actions/workflows/asg_add_node.yaml
+++ b/packs/autoscale/actions/workflows/asg_add_node.yaml
@@ -103,8 +103,8 @@ workflows:
           metadata:
             asg: <% $.asg %>
         publish:
-          ipv4_address: '<% $.create_new_node.result.public_ips[1] %>'
-          ipv6_address: '<% $.create_new_node.result.public_ips[0] %>'
+          ipv4_address: '<% $.create_new_node.result.public_ipv4 %>'
+          ipv6_address: '<% $.create_new_node.result.public_ipv6 %>'
         on-success:
           - get_total_node_count
         on-error:

--- a/packs/autoscale/actions/workflows/asg_create.yaml
+++ b/packs/autoscale/actions/workflows/asg_create.yaml
@@ -20,6 +20,7 @@ workflows:
       - expand_delay
       - deflate_by
       - deflate_delay
+      - initial_status
       - channel
       - application_name
     task-defaults:
@@ -167,6 +168,15 @@ workflows:
         input:
           key: 'asg.<% $.name %>.vm_image_id'
           value: <% str($.vm_image_id) %>
+        on-success:
+          - store_initial_status
+      store_initial_status:
+        action: st2.kv.set
+        policies:
+          wait-before: 1
+        input:
+          key: 'asg.<% $.name %>.status'
+          value: <% str($.initial_status) %>
         on-success:
           - store_expand_by_nodes
       store_expand_by_nodes:

--- a/packs/autoscale/actions/workflows/asg_deflate.yaml
+++ b/packs/autoscale/actions/workflows/asg_deflate.yaml
@@ -13,6 +13,14 @@ workflows:
       on-error:
         - fail
     tasks:
+      update_group_start_status:
+        action: st2.kv.set
+        input:
+          key: 'asg.<% $.asg %>.status'
+          value: 'deflating'
+          ttl: 900
+        on-success:
+          - get_chatops_room
       get_chatops_room:
         action: st2.kv.get
         input:
@@ -91,4 +99,10 @@ workflows:
         input:
           message: "```ASG[<% %.asg %>] ASG is slimmer now. Looking good!```"
           channel: <% $.channel %>
-
+        on-success:
+          - update_group_end_status
+      update_group_end_status:
+        action: st2.kv.set
+        input:
+          key: 'asg.<% $.asg %>.status'
+          value: 'idle'

--- a/packs/autoscale/actions/workflows/asg_delete_node.yaml
+++ b/packs/autoscale/actions/workflows/asg_delete_node.yaml
@@ -56,7 +56,7 @@ workflows:
         input:
           vm_id: <% $.vm_id %>
         publish:
-          ipv4_address: <% $.get_node_ip.result.public_ips[1] %>
+          ipv4_address: <% $.get_node_ip.result.public_ipv4 %>
         on-success:
           - get_loadbalancer_id
         on-error:

--- a/packs/autoscale/actions/workflows/asg_expand.yaml
+++ b/packs/autoscale/actions/workflows/asg_expand.yaml
@@ -13,6 +13,14 @@ workflows:
       on-error:
         - fail
     tasks:
+      update_group_start_status:
+        action: st2.kv.set
+        input:
+          key: 'asg.<% $.asg %>.status'
+          value: 'expanding'
+          ttl: 900
+        on-success:
+          - get_chatops_channel
       get_chatops_channel:
         action: st2.kv.get
         input:
@@ -93,3 +101,10 @@ workflows:
         input:
           message: "```ASG[<% $.asg %>] ASG Successfully Expanded!```"
           channel: <% $.channel %>
+        on-success:
+          - update_group_end_status
+      update_group_end_status:
+        action: st2.kv.set
+        input:
+          key: 'asg.<% $.asg %>.status'
+          value: 'idle'

--- a/packs/autoscale/actions/workflows/crit_alert.yaml
+++ b/packs/autoscale/actions/workflows/crit_alert.yaml
@@ -30,5 +30,5 @@ workflows:
       begin_expand:
         action: slack.post_message
         input:
-          message: "CRIT ALERT FOR <% %.asg %>"
+          message: "CRIT ALERT FOR <% $.asg %>"
           channel: "#bot-testing"

--- a/packs/autoscale/rules/newrelic_crit_alert.yaml
+++ b/packs/autoscale/rules/newrelic_crit_alert.yaml
@@ -8,7 +8,7 @@
     trigger.alert.severity:
       type: eq
       pattern: 'critical'
-    trigger.alert_policy_name:
+    trigger.alert.alert_policy_name:
       type: eq
       pattern: "Default server alert policy"
     trigger.alert.long_description:

--- a/packs/autoscale/rules/newrelic_crit_alert.yaml
+++ b/packs/autoscale/rules/newrelic_crit_alert.yaml
@@ -11,7 +11,7 @@
     trigger.alert_policy_name:
       type: eq
       pattern: "Default server alert policy"
-    trigger.long_description:
+    trigger.alert.long_description:
       type: startswith
       pattern: 'Alert opened'
   action:

--- a/packs/autoscale/rules/newrelic_crit_alert.yaml
+++ b/packs/autoscale/rules/newrelic_crit_alert.yaml
@@ -17,4 +17,4 @@
   action:
     ref: autoscale.crit_alert
     parameters:
-      application_name: "Default Application"
+      application: "Default Application"

--- a/packs/autoscale/rules/newrelic_recovery_alert.yaml
+++ b/packs/autoscale/rules/newrelic_recovery_alert.yaml
@@ -8,7 +8,7 @@
     trigger.alert.severity:
       type: eq
       pattern: 'critical'
-    trigger.alert_policy_name:
+    trigger.alert.alert_policy_name:
       type: eq
       pattern: "Default server alert policy"
     trigger.alert.long_description:

--- a/packs/autoscale/rules/newrelic_recovery_alert.yaml
+++ b/packs/autoscale/rules/newrelic_recovery_alert.yaml
@@ -17,4 +17,4 @@
   action:
     ref: autoscale.recovery_alert
     parameters:
-      application_name: "Default Application"
+      application: "Default Application"

--- a/packs/autoscale/rules/newrelic_recovery_alert.yaml
+++ b/packs/autoscale/rules/newrelic_recovery_alert.yaml
@@ -11,7 +11,7 @@
     trigger.alert_policy_name:
       type: eq
       pattern: "Default server alert policy"
-    trigger.long_description:
+    trigger.alert.long_description:
       type: startswith
       pattern: "Alert ended"
   action:

--- a/packs/autoscale/sensors/autoscale_governor.yaml
+++ b/packs/autoscale/sensors/autoscale_governor.yaml
@@ -2,6 +2,7 @@
 class_name: "AutoscaleGovernorSensor"
 entry_point: "autoscale_governor_sensor.py"
 description: Autoscale Pulse manager to automatically deflate non-troubled ASGs
+poll_interval: 60
 trigger_types:
   -
     name: 'ScaleDownPulse'

--- a/packs/autoscale/sensors/autoscale_governor_sensor.py
+++ b/packs/autoscale/sensors/autoscale_governor_sensor.py
@@ -96,10 +96,20 @@ class AutoscaleGovernorSensor(PollingSensor):
         return check
 
     def _max_bound_check(self, max_nodes, total_nodes):
-        check = True if total_nodes > max_nodes else False
+        """
+        Make sure we have not reached the threshold and are not above max_nodes.
+
+        We only want to send scale up pulse if we are not above max_nodes threshold.
+        """
+        check = True if total_nodes < max_nodes else False
         return check
 
     def _min_bound_check(self, min_nodes, total_nodes):
+        """
+        Make sure we have not reached the min_nodes threshold.
+
+        We only want to scale down if current number of nodes is greater than min_nodes.
+        """
         check = True if total_nodes > min_nodes else False
         return check
 

--- a/packs/autoscale/sensors/autoscale_governor_sensor.py
+++ b/packs/autoscale/sensors/autoscale_governor_sensor.py
@@ -23,8 +23,8 @@ class AutoscaleGovernorSensor(PollingSensor):
         self._kvp_get = self._sensor_service.get_value
 
         self._trigger = {
-            'expand': 'ScaleUpPulse',
-            'deflate': 'ScaleDownPulse'
+            'expand': 'autoscale.ScaleUpPulse',
+            'deflate': 'autoscale.ScaleDownPulse'
         }
         self._bound = {
             'expand': 'max',


### PR DESCRIPTION
### 1. Reference the right fields in the trigger inside the new relic critical and recovery rule

https://gist.github.com/Kami/2d424ba856d1799809d5

Rule was referencing `trigger.long_description` field, but it looks like it should be `trigger.alert.long_description` since the top level trigger instance object doesn't have this attribute. Same issue exists for `trigger.alert_policy_name` - should be `trigger.alert.alert_policy_name`.

Here is a trigger instance in question:

```python
{'alert': {u'account_name': u'fryman.io',
           u'alert_policy_name': u'Default server alert policy',
           u'alert_url': u'https://rpm.newrelic.com/accounts/880740/incidents/11717078',
           u'created_at': u'2015-02-03T01:07:00Z',
           u'long_description': u'Alert opened: CPU > 80%',
           u'message': u'CPU > 80%',
           u'server_events': [{u'created_at': u'2015-02-03T01:07:00Z',
                               u'message': u'CPU > 60%',
                               u'server': u'glaswegians-clops'},
                              {u'created_at': u'2015-02-03T01:07:00Z',
                               u'message': u'CPU > 80%',
                               u'server': u'glaswegians-clops'}],
           u'servers': [u'glaswegians-clops'],
           u'severity': u'critical',
           u'short_description': u'New alert on glaswegians-clops'},
 'header': {'Accept': u'*/*',
            'Content-Length': u'844',
            'Content-Type': u'application/x-www-form-urlencoded',
            'Host': u'localhost:10001',
            'User-Agent': u'curl/7.35.0'}}
```

And looking at the sensor, the fix is indeed correct since all the attributes are included inside the `alert` dict https://github.com/StackStorm/st2contrib/blob/master/packs/newrelic/sensors/newrelic_application_sensor.py#L168

### 2. Use the correct action parameter name inside the new relic critical and recovery alert rule

https://gist.github.com/Kami/a0bbfeb8d37993c8fd8b

`autoscale.{crit,recovery_aler}` action expects attribute `application` and not `application_name` as an input. See https://github.com/StackStorm/st2incubator/blob/master/packs/autoscale/actions/crit_alert.yaml#L8.

### 3. Fix typo in `crit_alert.yaml` workflow

Exception: https://gist.github.com/Kami/1c559790ee33cfa8a930
Fix in: d40e2dae0cd109b52a5b52a508aa5e4ad54449b1

### 4. Fix max_bound check in the scaling governor

98df9ce582ca467cb4bcd1b313f493f3b73abce2

### 5. Fix trigger name

Exception: https://gist.github.com/Kami/cd5b79563607c53aa74d
Fix: 637cdda69112d3037543898be730c93483828255

### 6. Fix a bug with adding a node to the loadbalancer and dns record creation failing

Sometimes those two tasks would fail because we picked up IPv6 and not IPv4 address (order in public_ips attribute is not guaranteed).

Fix: e0a1c8d8ee78f03599e78ca86861bf4d637fb8c1