### PR TITLE
Introduce new ASG "status" variable and use it to prevent race conditions

### DIFF
--- a/packs/autoscale/README.md
+++ b/packs/autoscale/README.md
@@ -84,6 +84,10 @@ section includes a list of the used datastore items along with their purpose.
 
 ### Temporary Data
 
+* ``asg.<asg group name>.status`` (string) - Current status of the group (``idle/expanding/deflating``).
+  Internally this variable is used to prevent race conditions which can occur if the time between the
+  group creation and the initial expansion / deflation event is greater than ``delay`` minutes or if the
+  actual expansion / deflation process takes more than ``delay`` minutes.
 * ``asg.<asg group name>.total_nodes`` (int) - Current number of active nodes in this group.
 * ``asg.<asg group name>.last_expand_timestamp`` (int) - Timestamp when this group was last expanded.
 * ``asg.<asg group name>.last_deflate_timestamp`` (int) - Timestamp when this group was last deflated.

--- a/packs/autoscale/actions/asg_create.yaml
+++ b/packs/autoscale/actions/asg_create.yaml
@@ -44,7 +44,7 @@ parameters:
   expand_delay:
     type: integer
     description: Length of time (in minutes) between autoscale expansion events
-    default: 10
+    default: 20
   deflate_by:
     type: integer
     description: Number of nodes to deflate-by at a time during auto-scaling
@@ -61,6 +61,11 @@ parameters:
     type: string
     description: VM Size ID (use rackspace.list_vm_sizes to discover)
     default: '00a5dffd-1f9a-47a8-9ccc-7267a362a9da'
+  initial_status:
+    type: string
+    description: Initial auto scale group status
+    default: idle
+    immutable: true
   channel:
     type: string
     description: Slack channel to send ChatOps events

--- a/packs/autoscale/actions/workflows/asg_create.yaml
+++ b/packs/autoscale/actions/workflows/asg_create.yaml
@@ -20,6 +20,7 @@ workflows:
       - expand_delay
       - deflate_by
       - deflate_delay
+      - initial_status
       - channel
       - application_name
     task-defaults:
@@ -167,6 +168,15 @@ workflows:
         input:
           key: 'asg.<% $.name %>.vm_image_id'
           value: <% str($.vm_image_id) %>
+        on-success:
+          - store_initial_status
+      store_initial_status:
+        action: st2.kv.set
+        policies:
+          wait-before: 1
+        input:
+          key: 'asg.<% $.name %>.status'
+          value: <% str($.initial_status) %>
         on-success:
           - store_expand_by_nodes
       store_expand_by_nodes:

--- a/packs/autoscale/actions/workflows/asg_deflate.yaml
+++ b/packs/autoscale/actions/workflows/asg_deflate.yaml
@@ -13,6 +13,14 @@ workflows:
       on-error:
         - fail
     tasks:
+      update_start_group_status:
+        action: st2.kv.set
+        input:
+          key: 'asg.<% $.name %>.status'
+          value: 'deflating'
+          ttl: 900
+        on-success:
+          - get_chatops_room
       get_chatops_room:
         action: st2.kv.get
         input:
@@ -91,4 +99,10 @@ workflows:
         input:
           message: "```ASG[<% %.asg %>] ASG is slimmer now. Looking good!```"
           channel: <% $.channel %>
-
+        on-success:
+          - update_end_group_status
+      update_end_group_status:
+        action: st2.kv.set
+        input:
+          key: 'asg.<% $.name %>.status'
+          value: 'idle'

--- a/packs/autoscale/actions/workflows/asg_deflate.yaml
+++ b/packs/autoscale/actions/workflows/asg_deflate.yaml
@@ -16,7 +16,7 @@ workflows:
       update_start_group_status:
         action: st2.kv.set
         input:
-          key: 'asg.<% $.name %>.status'
+          key: 'asg.<% $.asg %>.status'
           value: 'deflating'
           ttl: 900
         on-success:
@@ -104,5 +104,5 @@ workflows:
       update_end_group_status:
         action: st2.kv.set
         input:
-          key: 'asg.<% $.name %>.status'
+          key: 'asg.<% $.asg %>.status'
           value: 'idle'

--- a/packs/autoscale/actions/workflows/asg_deflate.yaml
+++ b/packs/autoscale/actions/workflows/asg_deflate.yaml
@@ -13,7 +13,7 @@ workflows:
       on-error:
         - fail
     tasks:
-      update_start_group_status:
+      update_group_start_status:
         action: st2.kv.set
         input:
           key: 'asg.<% $.asg %>.status'
@@ -100,8 +100,8 @@ workflows:
           message: "```ASG[<% %.asg %>] ASG is slimmer now. Looking good!```"
           channel: <% $.channel %>
         on-success:
-          - update_end_group_status
-      update_end_group_status:
+          - update_group_end_status
+      update_group_end_status:
         action: st2.kv.set
         input:
           key: 'asg.<% $.asg %>.status'

--- a/packs/autoscale/actions/workflows/asg_expand.yaml
+++ b/packs/autoscale/actions/workflows/asg_expand.yaml
@@ -16,7 +16,7 @@ workflows:
       update_start_group_status:
         action: st2.kv.set
         input:
-          key: 'asg.<% $.name %>.status'
+          key: 'asg.<% $.asg %>.status'
           value: 'expanding'
           ttl: 900
         on-success:
@@ -106,5 +106,5 @@ workflows:
       update_end_group_status:
         action: st2.kv.set
         input:
-          key: 'asg.<% $.name %>.status'
+          key: 'asg.<% $.asg %>.status'
           value: 'idle'

--- a/packs/autoscale/actions/workflows/asg_expand.yaml
+++ b/packs/autoscale/actions/workflows/asg_expand.yaml
@@ -13,6 +13,14 @@ workflows:
       on-error:
         - fail
     tasks:
+      update_start_group_status:
+        action: st2.kv.set
+        input:
+          key: 'asg.<% $.name %>.status'
+          value: 'expanding'
+          ttl: 900
+        on-success:
+          - get_chatops_channel
       get_chatops_channel:
         action: st2.kv.get
         input:
@@ -93,3 +101,10 @@ workflows:
         input:
           message: "```ASG[<% $.asg %>] ASG Successfully Expanded!```"
           channel: <% $.channel %>
+        on-success:
+          - update_end_group_status
+      update_end_group_status:
+        action: st2.kv.set
+        input:
+          key: 'asg.<% $.name %>.status'
+          value: 'idle'

--- a/packs/autoscale/actions/workflows/asg_expand.yaml
+++ b/packs/autoscale/actions/workflows/asg_expand.yaml
@@ -13,7 +13,7 @@ workflows:
       on-error:
         - fail
     tasks:
-      update_start_group_status:
+      update_group_start_status:
         action: st2.kv.set
         input:
           key: 'asg.<% $.asg %>.status'
@@ -102,8 +102,8 @@ workflows:
           message: "```ASG[<% $.asg %>] ASG Successfully Expanded!```"
           channel: <% $.channel %>
         on-success:
-          - update_end_group_status
-      update_end_group_status:
+          - update_group_end_status
+      update_group_end_status:
         action: st2.kv.set
         input:
           key: 'asg.<% $.asg %>.status'

--- a/packs/autoscale/sensors/autoscale_governor.yaml
+++ b/packs/autoscale/sensors/autoscale_governor.yaml
@@ -2,6 +2,7 @@
 class_name: "AutoscaleGovernorSensor"
 entry_point: "autoscale_governor_sensor.py"
 description: Autoscale Pulse manager to automatically deflate non-troubled ASGs
+poll_interval: 60
 trigger_types:
   -
     name: 'ScaleDownPulse'

--- a/packs/autoscale/sensors/autoscale_governor_sensor.py
+++ b/packs/autoscale/sensors/autoscale_governor_sensor.py
@@ -14,6 +14,12 @@ eventlet.monkey_patch(
     thread=True,
     time=True)
 
+GROUP_ACTIVE_STATUS = [
+    'expanding',
+    'deflating'
+]
+
+
 class AutoscaleGovernorSensor(PollingSensor):
     def __init__(self, sensor_service, config=None, poll_interval=30):
         super(AutoscaleGovernorSensor, self).__init__(sensor_service=sensor_service,
@@ -75,11 +81,17 @@ class AutoscaleGovernorSensor(PollingSensor):
         trigger_type         = self._trigger[action]
         bound                = self._bound[action]
 
+        group_status         = self._kvp_get('asg.%s.status' % (asg), local=False)
         last_event_timestamp = self._kvp_get('asg.%s.last_%s_timestamp' % (asg, action), local=False)
         event_delay          = self._kvp_get('asg.%s.%s_delay' % (asg, action), local=False)
         current_node_count   = self._kvp_get('asg.%s.total_nodes' % (asg), local=False)
         node_bound           = self._kvp_get('asg.%s.%s_nodes' % (asg, bound), local=False)
         total_nodes          = self._kvp_get('asg.%s.total_nodes' % (asg), local=False)
+
+        if group_status in GROUP_ACTIVE_STATUS:
+            self._logger.info("AutoScaleGovernor: Autoscale group is currently %s. Skipping..." %
+                              (group_status))
+            return
 
         # ensure we have all the required variables
         if last_event_timestamp and event_delay and current_node_count and node_bound and total_nodes:

--- a/packs/autoscale/sensors/autoscale_governor_sensor.py
+++ b/packs/autoscale/sensors/autoscale_governor_sensor.py
@@ -21,7 +21,7 @@ GROUP_ACTIVE_STATUS = [
 
 
 class AutoscaleGovernorSensor(PollingSensor):
-    def __init__(self, sensor_service, config=None, poll_interval=30):
+    def __init__(self, sensor_service, config=None, poll_interval=60):
         super(AutoscaleGovernorSensor, self).__init__(sensor_service=sensor_service,
                                                   config=config,
                                                   poll_interval=poll_interval)


### PR DESCRIPTION
This pull request introduces a new "status" variable which is used to prevent race conditions (multiple governor up / down events being emitted in a short time frame) in the autoscaling process.

![selection_185](https://cloud.githubusercontent.com/assets/125088/6948746/10b1649c-d8b0-11e4-8d05-2edd4c3664d4.png)

This issue would occur if a time between the initial group creation and the first expansion / deflation event end time is greater than ``delay`` minutes or if the expansion / deflation process itself takes more than ``delay`` minutes.