### PR TITLE
[RFC] Create a Librato annotation when a release is created

### DIFF
--- a/packs/st2cd/actions/st2cd_add_annotation_for_release.yaml
+++ b/packs/st2cd/actions/st2cd_add_annotation_for_release.yaml
@@ -1,0 +1,19 @@
+---
+  name: "st2_add_annotation_for_release"
+  runner_type: "action-chain"
+  description: "Creates Librato annotation for a release"
+  enabled: true
+  entry_point: "workflows/st2_add_annotation_for_release.yaml"
+  parameters:
+    st2_repo:
+      type: "string"
+      description: "Url of the st2 repo to clone"
+      default: "https://github.com/StackStorm/st2.git"
+    st2_repo_target:
+      type: "string"
+      default: "/home/stanley/st2"
+      description: "Path to clone st2 repo to."
+    branch:
+      type: "string"
+      description: "st2 branch to use."
+      required: true

--- a/packs/st2cd/actions/workflows/st2_add_annotation_for_release.yaml
+++ b/packs/st2cd/actions/workflows/st2_add_annotation_for_release.yaml
@@ -1,0 +1,45 @@
+---
+  chain:
+    -
+      name: "get_current_build"
+      ref: "st2cd.kvstore"
+      params:
+        key: "st2_{{branch}}_build_number"
+        action: "get"
+      on-success: "get_build_server"
+    -
+      name: "get_build_server"
+      ref: "linux.dig"
+      params:
+        hostname: "st2build.service.consul"
+        rand: true
+        count: 1
+      on-success: "clone_repo"
+    -
+      name: "clone_repo"
+      ref: "st2cd.git_clone"
+      params:
+        hosts: "{{get_build_server.result[0]}}"
+        repo: "{{st2_repo}}"
+        branch: "{{branch}}"
+        target: "{{st2_repo_target}}"
+      on-success: "retrieve_st2_version"
+    -
+      name: "retrieve_st2_version"
+      ref: "st2cd.version_hack"
+      params:
+        hosts: "{{get_build_server.result[0]}}"
+        repo: "{{clone_repo[get_build_server.result[0]].stdout}}"
+        build: "{{get_current_build.result}}"
+      publish:
+        st2_version: "{{ retrieve_st2_version[build_server].stdout }}"
+      on-success: "add_librato_annotation"
+    -
+      name: "add_librato_annotation"
+      ref: "librato.add_annotation"
+      params:
+        stream: "st2-releases"
+        title: "Released v{{ st2_version }}"
+        description: "Released StackStorm version {{ st2_version }}"
+
+  default: "get_current_build"

--- a/packs/st2cd/rules/st2_add_librato_annotation_for_release.yaml
+++ b/packs/st2cd/rules/st2_add_librato_annotation_for_release.yaml
@@ -1,0 +1,17 @@
+---
+    name: "st2_add_librato_annotation_for_release"
+    description: "Creates librato annotation when a release is created."
+    enabled: true
+    trigger:
+        type: "core.st2.generic.actiontrigger"
+    criteria:
+        trigger.body.ref:
+            pattern: "^refs/heads/v(\\d+\\.)(\\d+)$"
+            type: "matchregex"
+        trigger.body.repository.full_name:
+            pattern: "StackStorm/st2"
+            type: "equals"
+    action:
+        ref: "st2cd.st2_add_annotation_for_release"
+        parameters:
+            branch: "{{trigger.body.ref | replace("refs/heads/", "")}}"


### PR DESCRIPTION
With this change we will create a new annotation in Librato when a release is created.

This way we can correlate other metrics to those annotations.

Depends on #169