### PR TITLE
Added package clean up

### DIFF
--- a/packs/st2cd/actions/workflows/st2_pkg_ubuntu14.yaml
+++ b/packs/st2cd/actions/workflows/st2_pkg_ubuntu14.yaml
@@ -9,6 +9,13 @@
         count: 1
       publish:
         build_server: "{{get_build_server.result[0]}}"
+      on-success: "purge_old_pkgs"
+    -
+      name: "purge_old_pkgs"
+      ref: "core.remote"
+      params:
+        hosts: "{{build_server}"
+        cmd: "find /home/stanley/debbuild/ -name *.deb -type d -mmin +5 -delete"
       on-success: "clone_repo"
     - 
       name: "clone_repo"


### PR DESCRIPTION
This is related to https://github.com/StackStorm/st2/pull/1447

We were not cleaning up old packages before copying them over to the downloads server.  This was causing excessive copy times and causing errors fetching the latest version number.  The repos have been cleaned up and the bootstrap script now has the correct sort order for the versions.