### PR TITLE
Document available configuration options for the hubot pack

### DIFF
--- a/packs/hubot/README.md
+++ b/packs/hubot/README.md
@@ -16,6 +16,9 @@ in a portable way
 * Deployments
 * Variable Hubot Location
 
+## Configuration
+
+* ``endpoint`` - Base URL to the hubot HTTP listener (e.g. http://localhost:8080/)
 
 ## Actions
 


### PR DESCRIPTION
On a related note, if hubot pack is the defacto pack which should be used with our ChatOps solution, we should move it to `st2contrib`.