### PR TITLE
Allow raw JSON to be passed to hubot.post_result

### DIFF
--- a/packs/hubot/actions/post_result.py
+++ b/packs/hubot/actions/post_result.py
@@ -47,7 +47,13 @@ def format_localrunner_result(result, do_serialize=True):
     # Add in various properties if they have values
     stdout = result.get('stdout', None)
     if stdout:
-        output['stdout'] = stdout.strip()
+        try:
+            if isinstance(stdout, six.string_types):
+                output['stdout'] = stdout
+            else:
+                output['stdout'] = stdout.strip()
+        except AttributeError:
+            output['stdout'] = stdout
     stderr = result.get('stderr', None)
     if stderr:
         output['stderr'] = stderr.strip()
@@ -85,7 +91,13 @@ def format_pythonrunner_result(result):
         output['result'] = result_
     stdout = result.get('stdout', None)
     if stdout:
-        output['stdout'] = stdout.strip()
+        try:
+            if isinstance(stdout, six.string_types):
+                output['stdout'] = stdout
+            else:
+                output['stdout'] = stdout.strip()
+        except AttributeError:
+            output['stdout'] = stdout
     stderr = result.get('stderr', None)
     if stderr:
         output['stderr'] = stderr.strip()

--- a/packs/hubot/actions/post_result.py
+++ b/packs/hubot/actions/post_result.py
@@ -47,13 +47,10 @@ def format_localrunner_result(result, do_serialize=True):
     # Add in various properties if they have values
     stdout = result.get('stdout', None)
     if stdout:
-        try:
-            if isinstance(stdout, six.string_types):
-                output['stdout'] = stdout
-            else:
-                output['stdout'] = stdout.strip()
-        except AttributeError:
+        if isinstance(stdout, six.string_types):
             output['stdout'] = stdout
+        else:
+            output['stdout'] = stdout.strip()
     stderr = result.get('stderr', None)
     if stderr:
         output['stderr'] = stderr.strip()
@@ -91,13 +88,10 @@ def format_pythonrunner_result(result):
         output['result'] = result_
     stdout = result.get('stdout', None)
     if stdout:
-        try:
-            if isinstance(stdout, six.string_types):
-                output['stdout'] = stdout
-            else:
-                output['stdout'] = stdout.strip()
-        except AttributeError:
+        if isinstance(stdout, six.string_types):
             output['stdout'] = stdout
+        else:
+            output['stdout'] = stdout.strip()
     stderr = result.get('stderr', None)
     if stderr:
         output['stderr'] = stderr.strip()


### PR DESCRIPTION
As reported by @jtopjian, this PR fixes conditions where raw JSON is passed
to hubot.post_result and the `strip()` call was failing. This is because
`stdout` is converted to JSON by the localrunner and pythonrunner before
being returned.

Fixes #218