### PR TITLE
Add Branch Deployments to Puprun Action

### DIFF
--- a/packs/st2cd/actions/puprun.yaml
+++ b/packs/st2cd/actions/puprun.yaml
@@ -11,12 +11,16 @@
     environment:
       type: "string"
       description: "Puppet Environment (aka: git branch) to run. Will revert to 'production' when deleted"
+      default: "production"
     role:
       type: "string"
       description: "Apply a specific role to a machine (will remain on this role until changed)"
+    env:
+      default:
+        environment: "{{environment}}"
     cmd:
       immutable: false
-      default: "{% if environment %}environment={{environment}}{% endif %} {% if role %}role={{role}}{% endif %} puprun"
+      default: "puprun"
     kwarg_op:
       immutable: true
       default: "--"

--- a/packs/st2cd/actions/puprun.yaml
+++ b/packs/st2cd/actions/puprun.yaml
@@ -4,14 +4,19 @@
   description: "Executes puprun command"
   enabled: true
   entry_point: ""
-  parameters: 
-    sudo: 
+  parameters:
+    sudo:
       immutable: true
       default: true
-    cmd: 
+    environment:
+      type: "string"
+      description: "Puppet Environment (aka: git branch) to run. Will revert to 'production' when deleted"
+    role:
+      type: "string"
+      description: "Apply a specific role to a machine (will remain on this role until changed)"
+    cmd:
       immutable: false
-      default: "puprun"
-    kwarg_op: 
+      default: "{% if environment %}environment={{environment}}{% endif %} {% if role %}role={{role}}{% endif %} puprun"
+    kwarg_op:
       immutable: true
       default: "--"
-


### PR DESCRIPTION
This PR adds the ability to run arbitrary puppet environments, which map 1:1 to branches on the st2puppet project.