### PR TITLE
Re-enabling selenium tests

### DIFF
--- a/packs/st2cd/actions/workflows/st2_e2e_tests.yaml
+++ b/packs/st2cd/actions/workflows/st2_e2e_tests.yaml
@@ -173,5 +173,19 @@
         action: "examples.mistral_examples"
         hosts: "{{hostname}}"
         timeout: 600
+      on-success: "selenium"		
+    -		
+      name: "selenium"
+      ref: "webui.selenium"
+      params:
+        branch: "master"
+        repo: "https://github.com/StackStorm/st2e2e.git"
+        web_host: "{{hostname}}"
+      on-failure: "ignore_selenium_failure"
+    -		
+      name: "ignore_selenium_failure"
+      ref: "core.local"
+      params:
+        cmd: "echo 'Selenium tests failed, but all other tests were successful. Setting overall status to success'"
 
   default: "get_st2_token"


### PR DESCRIPTION
Re-enabling selenium tests; if they fail, however, the overall flow will still succeed. This will allow me to debug random failures which were observed during CI execution (not reproducible elsewhere)