### PR TITLE
Add timeout and retries to sensor

### DIFF
--- a/packs/typeform/config.yaml
+++ b/packs/typeform/config.yaml
@@ -3,8 +3,8 @@ api_key: ""
 form_id: ""
 completed: ""
 sensor:
-  retries: ""
-  timeout: ""
+  retries: 3
+  timeout: 20
 mysql:
   host: ""
   user: ""

--- a/packs/typeform/config.yaml
+++ b/packs/typeform/config.yaml
@@ -2,6 +2,9 @@
 api_key: ""
 form_id: ""
 completed: ""
+sensor:
+  retries: ""
+  timeout: ""
 mysql:
   host: ""
   user: ""

--- a/packs/typeform/config.yaml
+++ b/packs/typeform/config.yaml
@@ -4,6 +4,7 @@ form_id: ""
 completed: ""
 sensor:
   retries: 3
+  retry_delay: 30
   timeout: 20
 mysql:
   host: ""

--- a/packs/typeform/sensors/registration_sensor.py
+++ b/packs/typeform/sensors/registration_sensor.py
@@ -104,6 +104,7 @@ class TypeformRegistrationSensor(PollingSensor):
         headers = {}
         headers['Content-Type'] = 'application/x-www-form-urlencoded'
 
+        response = None
         for _ in range(self.retries + 1):
             try:
                 response = requests.request(
@@ -112,9 +113,8 @@ class TypeformRegistrationSensor(PollingSensor):
                     headers=headers,
                     timeout=self.sensor_config['timeout'],
                     params=data)
-            except Exception, e:
-                self.logger.info(e)
-                response = None
+            except Exception:
+                self.logger.info('Unable to connect to registrations API.', exc_info=True)
                 eventlet.sleep(self.retry_delay)
 
         if not response:

--- a/packs/typeform/sensors/registration_sensor.py
+++ b/packs/typeform/sensors/registration_sensor.py
@@ -94,13 +94,14 @@ class TypeformRegistrationSensor(PollingSensor):
         headers = {}
         headers['Content-Type'] = 'application/x-www-form-urlencoded'
 
-        for x in range(self.sensor_config.retries):
+        for x in range(self.sensor_config['retries']):
             try:
-                response = requests.request(method='GET',
-                                            url=self.url,
-                                            headers=headers,
-                                            timeout=self.sensor_config.timeout,
-                                            params=data)
+                response = requests.request(
+                    method='GET',
+                    url=self.url,
+                    headers=headers,
+                    timeout=self.sensor_config['timeout'],
+                    params=data)
             except Exception, e:
                 self.logger.info(e)
 

--- a/packs/typeform/sensors/registration_sensor.py
+++ b/packs/typeform/sensors/registration_sensor.py
@@ -5,6 +5,7 @@ import httplib
 import MySQLdb
 import MySQLdb.cursors
 import requests
+import time
 import urllib
 import urlparse
 
@@ -94,7 +95,7 @@ class TypeformRegistrationSensor(PollingSensor):
         headers = {}
         headers['Content-Type'] = 'application/x-www-form-urlencoded'
 
-        for x in range(self.sensor_config['retries']):
+        for x in range(int(self.sensor_config['retries'])):
             try:
                 response = requests.request(
                     method='GET',
@@ -104,8 +105,10 @@ class TypeformRegistrationSensor(PollingSensor):
                     params=data)
             except Exception, e:
                 self.logger.info(e)
+                response = None
+                time.sleep(30)
 
-        if not response.text:
+        if not response:
             raise Exception('Failed to connect to TypeForm API.')
 
         if response.status_code != httplib.OK:

--- a/packs/typeform/sensors/registration_sensor.py
+++ b/packs/typeform/sensors/registration_sensor.py
@@ -1,13 +1,12 @@
 # Requirements:
 # See ../requirements.txt
 
+import eventlet
 import httplib
 import MySQLdb
 import MySQLdb.cursors
 import requests
-import time
-import urllib
-import urlparse
+from six.moves import urllib_parse
 
 from st2reactor.sensor.base import PollingSensor
 
@@ -94,12 +93,12 @@ class TypeformRegistrationSensor(PollingSensor):
         self._sensor_service.dispatch(trigger, data)
 
     def _get_url(self, endpoint):
-        url = urlparse.urljoin(BASE_URL, endpoint)
+        url = urllib_parse.urljoin(BASE_URL, endpoint)
 
         return url
 
     def _get_api_registrations(self, params):
-        data = urllib.urlencode(params)
+        data = urllib_parse.urlencode(params)
         headers = {}
         headers['Content-Type'] = 'application/x-www-form-urlencoded'
 
@@ -114,7 +113,7 @@ class TypeformRegistrationSensor(PollingSensor):
             except Exception, e:
                 self.logger.info(e)
                 response = None
-                time.sleep(self.retry_delay)
+                eventlet.sleep(self.retry_delay)
 
         if not response:
             raise Exception('Failed to connect to TypeForm API.')

--- a/packs/typeform/sensors/registration_sensor.py
+++ b/packs/typeform/sensors/registration_sensor.py
@@ -33,7 +33,6 @@ class TypeformRegistrationSensor(PollingSensor):
         self._trigger_pack = 'typeform'
         self._trigger_ref = '.'.join([self._trigger_pack, 'registration'])
 
-        self.sensor_config = self._config.get('sensor', False)
         db_config = self._config.get('mysql', False)
         self.db = self._conn_db(host=db_config.get('host', None),
                                 user=db_config.get('user', None),
@@ -45,13 +44,16 @@ class TypeformRegistrationSensor(PollingSensor):
                                                                True)).lower()}
 
         self.url = self._get_url(self._config.get('form_id', None))
-        self.retries = int(self._config.get('retries', 3))
+
+        # sensor specific config.
+        self.sensor_config = self._config.get('sensor', {})
+        self.retries = int(self.sensor_config.get('retries', 3))
         if self.retries < 0:
             self.retries = 0
-        self.retry_delay = int(self._config.get('retry_delay', 30))
+        self.retry_delay = int(self.sensor_config.get('retry_delay', 30))
         if self.retry_delay < 0:
             self.retry_delay = 30
-        self.timeout = int(self._config.get('retries', 20))
+        self.timeout = int(self.sensor_config.get('retries', 20))
         if self.timeout < 0:
             self.timeout = 20
 


### PR DESCRIPTION
The Typeform sensor was dying on timeout to the Typeform API.  This adds a configurable timeout and number of retries.