### PR TITLE
Update from 012 release

### DIFF
--- a/packs/st2cd/actions/create_vm_role.meta.yaml
+++ b/packs/st2cd/actions/create_vm_role.meta.yaml
@@ -13,6 +13,10 @@
       type: "string"
       description: "Environment to deploy to"
       default: "staging"
+      enum:
+        - "production"
+        - "staging"
+        - "sandbox"
     key_name:
       type: "string"
       description: "SSH key to use during intial instance creation"
@@ -40,6 +44,7 @@
       default: "UBUNTU14"
       enum:
         - "RHEL6"
+        - "RHEL7"
         - "F20"
         - "F21"
         - "UBUNTU14"

--- a/packs/st2cd/actions/set_hostname_cloud.yaml
+++ b/packs/st2cd/actions/set_hostname_cloud.yaml
@@ -16,12 +16,13 @@
       required: true
       enum:
         - "RHEL6"
+        - "RHEL7"
         - "F20"
         - "F21"
         - "UBUNTU14"
     cmd:
       immutable: true
-      default: '{% if distro == "RHEL6" -%}{{redhat}}{% elif distro == "UBUNTU14" -%}{{ubuntu}}{% elif distro == "F20" -%}{{fedora}}{% elif distro == "F21" -%}{{fedora}}{% endif -%}'
+      default: '{% if distro == "RHEL6" or distro == "RHEL7" -%}{{redhat}}{% elif distro == "UBUNTU14" -%}{{ubuntu}}{% elif distro == "F20" -%}{{fedora}}{% elif distro == "F21" -%}{{fedora}}{% endif -%}'
     redhat:
       type: "string"
       immutable: true

--- a/packs/st2cd/actions/st2_finalize_release.meta.yaml
+++ b/packs/st2cd/actions/st2_finalize_release.meta.yaml
@@ -8,7 +8,7 @@
     st2_repo:
       type: "string"
       description: "Url of the st2 repo to clone"
-      default: "https://github.com/StackStorm/st2.git"
+      default: "git@github.com:StackStorm/st2.git"
     st2_repo_target:
       type: "string"
       default: "/home/stanley/st2"

--- a/packs/st2cd/actions/st2_tag_release_meta.yaml
+++ b/packs/st2cd/actions/st2_tag_release_meta.yaml
@@ -8,7 +8,7 @@
     st2_repo:
       type: "string"
       description: "Url of the st2 repo to clone"
-      default: "https://github.com/StackStorm/st2.git"
+      default: "git@github.com:StackStorm/st2.git"
     st2_repo_target:
       type: "string"
       default: "/home/stanley/st2"

--- a/packs/st2cd/rules/st2_deploy_test_v0.11_f20.json
+++ b/packs/st2cd/rules/st2_deploy_test_v0.11_f20.json
@@ -1,0 +1,42 @@
+{
+    "action": {
+        "parameters": {
+            "branch": "{{trigger.parameters.branch}}", 
+            "build": "{{trigger.parameters.build}}", 
+            "distro": "F20", 
+            "environment": "sandbox", 
+            "hostname": "st2-{{trigger.parameters.branch}}-{{trigger.execution_id}}", 
+            "repo": "{{trigger.parameters.repo}}", 
+            "revision": "{{trigger.parameters.revision}}", 
+            "version": "{{trigger.result.tasks[4].result.stdout}}"
+        }, 
+        "ref": "st2cd.st2_deploy_test"
+    }, 
+    "criteria": {
+        "trigger.action_name": {
+            "pattern": "st2cd.st2_pkg_f20", 
+            "type": "equals"
+        }, 
+        "trigger.parameters.branch": {
+            "pattern": "v0.11", 
+            "type": "equals"
+        }, 
+        "trigger.parameters.environment": {
+            "pattern": "staging", 
+            "type": "equals"
+        }, 
+        "trigger.status": {
+            "pattern": "succeeded", 
+            "type": "equals"
+        }
+    }, 
+    "description": "Test st2_deploy.sh on each build", 
+    "enabled": true, 
+    "name": "st2_deploy_test_v0.11_f20", 
+    "tags": [], 
+    "trigger": {
+        "pack": "core", 
+        "parameters": {}, 
+        "type": "core.st2.generic.actiontrigger"
+    }
+}

--- a/packs/st2cd/rules/st2_deploy_test_v0.11_ubuntu14.json
+++ b/packs/st2cd/rules/st2_deploy_test_v0.11_ubuntu14.json
@@ -1,0 +1,42 @@
+{
+    "action": {
+        "parameters": {
+            "branch": "{{trigger.parameters.branch}}", 
+            "build": "{{trigger.parameters.build}}", 
+            "distro": "UBUNTU14", 
+            "environment": "sandbox", 
+            "hostname": "st2-{{trigger.parameters.branch}}-{{trigger.execution_id}}", 
+            "repo": "{{trigger.parameters.repo}}", 
+            "revision": "{{trigger.parameters.revision}}", 
+            "version": "{{trigger.result.tasks[4].result.stdout}}"
+        }, 
+        "ref": "st2cd.st2_deploy_test"
+    }, 
+    "criteria": {
+        "trigger.action_name": {
+            "pattern": "st2cd.st2_pkg_ubuntu14", 
+            "type": "equals"
+        }, 
+        "trigger.parameters.branch": {
+            "pattern": "v0.11", 
+            "type": "equals"
+        }, 
+        "trigger.parameters.environment": {
+            "pattern": "staging", 
+            "type": "equals"
+        }, 
+        "trigger.status": {
+            "pattern": "succeeded", 
+            "type": "equals"
+        }
+    }, 
+    "description": "Test st2_deploy.sh on each build", 
+    "enabled": true, 
+    "name": "st2_deploy_test_v0.11_ubuntu14", 
+    "tags": [], 
+    "trigger": {
+        "pack": "core", 
+        "parameters": {}, 
+        "type": "core.st2.generic.actiontrigger"
+    }
+}

--- a/packs/st2cd/rules/st2_deploy_test_v0.12_f20.json
+++ b/packs/st2cd/rules/st2_deploy_test_v0.12_f20.json
@@ -1,0 +1,42 @@
+{
+    "action": {
+        "parameters": {
+            "branch": "{{trigger.parameters.branch}}", 
+            "build": "{{trigger.parameters.build}}", 
+            "distro": "F20", 
+            "environment": "sandbox", 
+            "hostname": "st2-{{trigger.parameters.branch}}-{{trigger.execution_id}}", 
+            "repo": "{{trigger.parameters.repo}}", 
+            "revision": "{{trigger.parameters.revision}}", 
+            "version": "{{trigger.result.tasks[4].result.stdout}}"
+        }, 
+        "ref": "st2cd.st2_deploy_test"
+    }, 
+    "criteria": {
+        "trigger.action_name": {
+            "pattern": "st2cd.st2_pkg_f20", 
+            "type": "equals"
+        }, 
+        "trigger.parameters.branch": {
+            "pattern": "v0.12", 
+            "type": "equals"
+        }, 
+        "trigger.parameters.environment": {
+            "pattern": "staging", 
+            "type": "equals"
+        }, 
+        "trigger.status": {
+            "pattern": "succeeded", 
+            "type": "equals"
+        }
+    }, 
+    "description": "Test st2_deploy.sh on each build", 
+    "enabled": true, 
+    "name": "st2_deploy_test_v0.12_f20", 
+    "tags": [], 
+    "trigger": {
+        "pack": "core", 
+        "parameters": {}, 
+        "type": "core.st2.generic.actiontrigger"
+    }
+}

--- a/packs/st2cd/rules/st2_deploy_test_v0.12_ubuntu14.json
+++ b/packs/st2cd/rules/st2_deploy_test_v0.12_ubuntu14.json
@@ -1,0 +1,42 @@
+{
+    "action": {
+        "parameters": {
+            "branch": "{{trigger.parameters.branch}}", 
+            "build": "{{trigger.parameters.build}}", 
+            "distro": "UBUNTU14", 
+            "environment": "sandbox", 
+            "hostname": "st2-{{trigger.parameters.branch}}-{{trigger.execution_id}}", 
+            "repo": "{{trigger.parameters.repo}}", 
+            "revision": "{{trigger.parameters.revision}}", 
+            "version": "{{trigger.result.tasks[4].result.stdout}}"
+        }, 
+        "ref": "st2cd.st2_deploy_test"
+    }, 
+    "criteria": {
+        "trigger.action_name": {
+            "pattern": "st2cd.st2_pkg_ubuntu14", 
+            "type": "equals"
+        }, 
+        "trigger.parameters.branch": {
+            "pattern": "v0.12", 
+            "type": "equals"
+        }, 
+        "trigger.parameters.environment": {
+            "pattern": "staging", 
+            "type": "equals"
+        }, 
+        "trigger.status": {
+            "pattern": "succeeded", 
+            "type": "equals"
+        }
+    }, 
+    "description": "Test st2_deploy.sh on each build", 
+    "enabled": true, 
+    "name": "st2_deploy_test_v0.12_ubuntu14", 
+    "tags": [], 
+    "trigger": {
+        "pack": "core", 
+        "parameters": {}, 
+        "type": "core.st2.generic.actiontrigger"
+    }
+}

--- a/packs/st2cd/rules/st2web_deploy_staging_f20.yaml
+++ b/packs/st2cd/rules/st2web_deploy_staging_f20.yaml
@@ -21,4 +21,4 @@
         ref: "st2cd.st2_web_deploy"
         parameters:
             hostname: "{{system.st2_stage_master_F20}}"
-            version: "0.12dev"
+            version: "{{system.st2_unstable_version}}"

--- a/packs/st2cd/rules/st2web_deploy_staging_ubuntu14.yaml
+++ b/packs/st2cd/rules/st2web_deploy_staging_ubuntu14.yaml
@@ -21,4 +21,4 @@
         ref: "st2cd.st2_web_deploy"
         parameters:
             hostname: "{{system.st2_stage_master_UBUNTU14}}"
-            version: "0.12dev"
+            version: "{{system.st2_unstable_version}}


### PR DESCRIPTION
These are issues discovered during the 0.12 release and updated locally.  I also lumped in some changes needed for RHEL7 support in here.

#### Updates

* Add RHEL7 to distro enum in create_vm_role workflow and associated actions
* Switch to git protocol from https for release workflows that need to write to git repos
* Use kvstore for unstable host version in st2web deploy workflows for master - previously hardcoded.
* Added st2_deploy test for versions 0.11 and 0.12 - These were written locally on the build server