### PR TITLE
Temporary fix YAQL dependency for Mistral install

### DIFF
--- a/packs/st2ci_mistral/actions/install_mistral.sh
+++ b/packs/st2ci_mistral/actions/install_mistral.sh
@@ -37,6 +37,13 @@ install_mistral() {
         exit 3
     fi
 
+    # Temporary hack to bypass conflict in pbr version.
+    VENV_PKG_DIR="$REPO/.venv/local/lib/python2.7/site-packages"
+    YAQL_REQ_FILE="$VENV_PKG_DIR/yaql-0.2.7-py2.7.egg-info/requires.txt"
+    if [[ -f "${YAQL_REQ_FILE}" ]]; then
+        sed -i 's/pbr>=0.6,!=0.7,<1.0/pbr<2.0,>=0.11/g' ${YAQL_REQ_FILE}
+    fi
+
     pip install -q mysql-python
     if [[ $? != 0 ]]
     then


### PR DESCRIPTION
Mistral is still using YAQL 0.2.7 and it has conflicts with other dependencies. The hack here is temporary to get thru the installation of Mistral. There'll be no negative impact from this fix.