### PR TITLE
Fix invalid email in autoscale pack

### DIFF
--- a/packs/autoscale/pack.yaml
+++ b/packs/autoscale/pack.yaml
@@ -4,5 +4,5 @@ name: autoscale
 description: autoscale
 version: 0.0.1
 author: jfryman
-email: jfryman@FryBook
+email: jfryman@FryBook.local
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/mnt/st2/st2common/st2common/bootstrap/base.py", line 100, in register_pack
    pack_db = self._register_pack(pack_name=pack_name, pack_dir=pack_dir)
  File "/mnt/st2/st2common/st2common/bootstrap/base.py", line 137, in _register_pack
    pack_db = Pack.add_or_update(pack_db)
  File "/mnt/st2/st2common/st2common/persistence/base.py", line 155, in add_or_update
    model_object = cls._get_impl().add_or_update(model_object)
  File "/mnt/st2/st2common/st2common/models/db/__init__.py", line 152, in add_or_update
    instance.save()
  File "/mnt/st2/virtualenv/local/lib/python2.7/site-packages/mongoengine/document.py", line 224, in save
    self.validate(clean=clean)
  File "/mnt/st2/virtualenv/local/lib/python2.7/site-packages/mongoengine/base/document.py", line 323, in validate
    raise ValidationError(message, errors=errors)
ValidationError: ValidationError (PackDB:None) (Invalid Mail-address: jfryman@FryBook: ['email'])
```