### PR TITLE
Fixes for check_dir_size.py - Make --threshold required and correct a typo (use instead of usage)

### DIFF
--- a/packs/st2-demos/actions/check_dir_size.py
+++ b/packs/st2-demos/actions/check_dir_size.py
@@ -12,7 +12,7 @@ parser.add_argument("-D", "--directory",
                     dest="directory", required=True)
 parser.add_argument("-t", "--threshold",
                     help="Maximum percentage of disk",
-                    dest="threshold")
+                    dest="threshold", required=True)
 parser.add_argument("-a", "--action",
                     help="Run this script as an action",
                     action="store_true",
@@ -74,6 +74,6 @@ if args.action is True or args.debug is True:
 else:
     print("%s is %s. Current Usage: %s" % (results['args']['directory'],
                                            results['status'],
-                                           results['use']) + '%')
+                                           results['usage']) + '%')
 
 sys.exit(exitcode)


### PR DESCRIPTION
While checking out the [Auto-remediation by example: handling out-of-disk-space](https://stackstorm.com/2015/10/05/auto-remediation-out-of-disk-space/) blog post.  I came a cross a couple of very minor bugs that prevented the script from running on the command line.