### PR TITLE
Temporary disable mistral merge with upstream rule

### DIFF
--- a/packs/st2ci/rules/mistral_os_master.yaml
+++ b/packs/st2ci/rules/mistral_os_master.yaml
@@ -1,7 +1,7 @@
 ---
 name: mistral_os_master
 description: Run integration tests and merge upstream changes from OpenStack Mistral master
-enabled: true
+enabled: false
 trigger:
   type: core.st2.CronTimer
   parameters:


### PR DESCRIPTION
Temporary prevent mistralclient changes from upstream to merge into our fork.