### PR TITLE
TypeForm Pack updates

### DIFF
--- a/packs/typeform/README.md
+++ b/packs/typeform/README.md
@@ -35,7 +35,7 @@ This pack ships with a sensor that checks the Typeform API for submissions to a 
 * form_id - This ID is displayed when you go to the URL for your form.  The format looks like this:
     * https://[USERNAME].typeform.com/to/[FORM_ID]
 
-PLEASE NOTE: the fields used in registration_sensor.py for user information are unique to your form.  E.g. EMAIL_FIELD = "email_7723200" which is listed in the provided registration_sensor.py file will not work for you.  To get the field names you need to use first create the form you want people to fill out, fill out a sample form, and then modify this URL with your information to get a JSON response the correct field names:
+PLEASE NOTE: the fields used in registration_sensor.py for user information are unique to your form.  E.g. EMAIL_FIELD = "email_7723200" which is listed in the provided registration_sensor.py file will not work for you.  To get the field names you need to use first create the form you want people to fill out, fill out a sample form, and then modify this URL with your information to get a JSON response with the correct field names:
 https://api.typeform.com/v0/form/[FORM_ID]?key=[API_key]&completed=true
 
 ### Actions

--- a/packs/typeform/README.md
+++ b/packs/typeform/README.md
@@ -35,6 +35,9 @@ This pack ships with a sensor that checks the Typeform API for submissions to a 
 * form_id - This ID is displayed when you go to the URL for your form.  The format looks like this:
     * https://[USERNAME].typeform.com/to/[FORM_ID]
 
+PLEASE NOTE: the fields used in registration_sensor.py for user information are unique to your form.  E.g. EMAIL_FIELD = "email_7723200" which is listed in the provided registration_sensor.py file will not work for you.  To get the field names you need to use first create the form you want people to fill out, fill out a sample form, and then modify this URL with your information to get a JSON response the correct field names:
+https://api.typeform.com/v0/form/[FORM_ID]?key=[API_key]&completed=true
+
 ### Actions
 In case you are interested in getting the list of submissions on demand, instead of running them from the sensor, you can use this action.
 

--- a/packs/typeform/actions/chains/register_and_invite.yaml
+++ b/packs/typeform/actions/chains/register_and_invite.yaml
@@ -2,7 +2,7 @@
   chain:
     -
       name: "insert_registration"
-      ref: "mysql.insert"
+      ref: "st2-mysql.insert"
       params:
         db: "community"
         table: "user_registration"

--- a/packs/typeform/actions/chains/send_slack_invite.yaml
+++ b/packs/typeform/actions/chains/send_slack_invite.yaml
@@ -2,7 +2,7 @@
   chain:
     -
       name: "insert_user"
-      ref: "mysql.insert"
+      ref: "st-2mysql.insert"
       params:
         db: "community"
         table: true


### PR DESCRIPTION
The following was done for the TypeForm pack:

The send_slack_invite.yaml file was in the rules folder and not
actions/chains.  Moved this to the correct folder.

The register_and_invite.yaml chain has a ref: “mysql.insert” although
that pack doesn’t exist.  I’ve updated this to point to
st2-mysql.insert which does exist.

The typeform sensor requires specific fields specified in the
registration_sensor.py file but there were no directions for this.
Added directions specifying that it’s needed as well as how to find the field IDs you need.