### PR TITLE
Upgrade setuptools

### DIFF
--- a/packs/mistral-dev/actions/install.sh
+++ b/packs/mistral-dev/actions/install.sh
@@ -43,6 +43,7 @@ fi
 # Temporary hack to get around oslo.utils bug.
 pip install -q netifaces
 
+pip install -U setuptools
 python setup.py develop
 
 # Setup plugins for custom actions.


### PR DESCRIPTION
The command "python setup.py develop" for installing mistral required a later version of setuptools.