### PR TITLE
Adding ST2-Splunk-VDX integration workflows

### DIFF
--- a/packs/st2-demos/actions/bgp_down_remed_chain.meta.yaml
+++ b/packs/st2-demos/actions/bgp_down_remed_chain.meta.yaml
@@ -1,0 +1,15 @@
+---
+  name: "bgp_down_remed_chain"
+  runner_type: "action-chain"
+  description: "Brocade IP Fabric bgp down remediation"
+  enabled: true
+  entry_point: "chains/bgp_down_remed_chain.yaml"
+  parameters:
+    host:
+      type: "string"
+      description: "IP of the switch"
+      required: true
+    neighbour:
+      type: "string"
+      description: "neighbour that has gone down"
+      required: true

--- a/packs/st2-demos/actions/bgp_down_remed_workflow.yaml
+++ b/packs/st2-demos/actions/bgp_down_remed_workflow.yaml
@@ -1,0 +1,14 @@
+---
+description: Run a series of simulated actions.
+enabled: true
+entry_point: workflows/bgp_down_remed_workflow.yaml
+name: bgp_down_remed_workflow
+pack: st2-demos
+parameters:
+  host:
+    required: true
+    type: string
+  neighbour:
+    required: true
+    type: string
+runner_type: mistral-v2

--- a/packs/st2-demos/actions/chains/bgp_down_remed_chain.yaml
+++ b/packs/st2-demos/actions/chains/bgp_down_remed_chain.yaml
@@ -1,0 +1,65 @@
+---
+    chain:
+        -
+            name: "notify_on_slack"
+            ref: "chatops.post_message"
+            parameters:
+                channel: "lkhtesting"
+                message: "BGP neighbour {{neighbour}} just went down on {{host}}"
+            on-success: "show_bgp_neighbours"
+            on-failure: "report_failure"
+        -
+            name: "show_bgp_neighbours"
+            ref: "clicrud.ops_command"
+            parameters:
+                host: "{{host}}"
+                command: "show ip bgp neighbors" 
+            on-success: "send_show_bgp_neighbours_to_slack"
+            on-failure: "report_failure"
+        -
+            name: "send_show_bgp_neighbours_to_slack"
+            ref: "chatops.post_message"
+            parameters:
+                message: "{{show_bgp_neighbours.result}}"
+                channel: 'lkhtesting'
+            on-success: "show_interface_brief"
+            on-failure: "report_failure"
+        -
+            name: "show_interface_brief"
+            ref: "clicrud.ops_command"
+            parameters:
+                host: "{{host}}"
+                command: "show ip int br"
+            on-success: "send_show_interface_brief_to_slack"
+            on-failure: "report_failure"
+        -
+            name: "send_show_interface_brief_to_slack"
+            ref: "chatops.post_message"
+            parameters:
+                message: "{{show_interface_brief.result}}"
+                channel: 'lkhtesting'
+            on-success: "send_jira_msg_to_slack"
+            on-failure: "report_failure"
+        -
+            name: "send_jira_msg_to_slack"
+            ref: "chatops.post_message"
+            parameters:
+                message: "Creating a Jira issue for this event!"
+                channel: 'lkhtesting'
+            on-success: "create_jira_issue"
+            on-failure: "report_failure"
+        -
+            name: "create_jira_issue"
+            ref: "jira.create_issue"
+            parameters:
+                type: "IT Help"
+                summary: "BGP neighbour down: {{neighbour}} on {{host}}"
+                description: "{{show_bgp_neighbours.result}}\n{{show_interface_brief.result}}"
+            on-failure: "report_failure"
+        -
+            name: "report_failure"
+            ref: "chatops.post_message"
+            parameters:
+                message: "Something went wrong in bgp down auto-remediation!"
+                channel: 'lkhtesting'
+    default: "notify_on_slack"

--- a/packs/st2-demos/actions/chains/link_flap_remed_chain.yaml
+++ b/packs/st2-demos/actions/chains/link_flap_remed_chain.yaml
@@ -1,0 +1,80 @@
+---
+    chain:
+        -
+            name: "notify_on_slack"
+            ref: "chatops.post_message"
+            parameters:
+                channel: "lkhtesting"
+                message: "Interface {{interface}} just went down on {{host}}"
+            on-success: "show_run_interface"
+            on-failure: "report_failure"
+        -
+            name: "show_run_interface"
+            ref: "clicrud.ops_command"
+            parameters:
+                host: "{{host}}"
+                command: "show run interface {{interface}}" 
+            on-success: "send_show_run_interface_to_slack"
+            on-failure: "report_failure"
+        -
+            name: "send_show_run_interface_to_slack"
+            ref: "chatops.post_message"
+            parameters:
+                message: "{{show_run_interface.result}}"
+                channel: 'lkhtesting'
+            on-success: "bring_up_msg_to_slack"
+            on-failure: "report_failure"
+        -
+            name: "bring_up_msg_to_slack"
+            ref: "chatops.post_message"
+            parameters:
+                message: "Trying to bring up the link {{interface}} on {{host}}!"
+                channel: 'lkhtesting'
+            on-success: "bring_up_link"
+            on-failure: "report_failure"
+        -
+            name: "bring_up_link"
+            ref: "clicrud.config_command"
+            parameters:
+                host: "{{host}}"
+                command: ["int {{interface}}","shut","no shut"]
+            on-success: "show_interface_detail"
+            on-failure: "report_failure"
+        -
+            name: "show_interface_detail"
+            ref: "clicrud.ops_command"
+            parameters:
+                host: "{{host}}"
+                command: "show interface {{interface}}"
+            on-success: "send_interface_details_to_slack"
+            on-failure: "report_failure"
+        -
+            name: "send_interface_details_to_slack"
+            ref: "chatops.post_message"
+            parameters:
+                message: "{{show_interface_detail.result}}"
+                channel: 'lkhtesting'
+            on-success: "send_zendesk_msg_to_slack"
+            on-failure: "report_failure"
+        -
+            name: "send_zendesk_msg_to_slack"
+            ref: "chatops.post_message"
+            parameters:
+                message: "Creating a Zendesk issue for this event!"
+                channel: 'lkhtesting'
+            on-success: "create_zendesk_tkt"
+            on-failure: "report_failure"
+        -
+            name: "create_zendesk_tkt"
+            ref: "zendesk.create_ticket"
+            parameters:
+                subject: "Link down: {{interface}} on {{host}}"
+                description: "{{show_run_interface.result}}\n{{show_interface_detail.result}}"
+            on-failure: "report_failure"
+        -
+            name: "report_failure"
+            ref: "chatops.post_message"
+            parameters:
+                message: "Something went wrong in link down auto-remediation!"
+                channel: 'lkhtesting'
+    default: "notify_on_slack"

--- a/packs/st2-demos/actions/link_flap_remed_chain.meta.yaml
+++ b/packs/st2-demos/actions/link_flap_remed_chain.meta.yaml
@@ -1,0 +1,15 @@
+---
+  name: "link_flap_remed_chain"
+  runner_type: "action-chain"
+  description: "Brocade IP Fabric link flap remediation"
+  enabled: true
+  entry_point: "chains/link_flap_remed_chain.yaml"
+  parameters:
+    host:
+      type: "string"
+      description: "IP of the switch"
+      required: true
+    interface:
+      type: "string"
+      description: "interface that has gone down"
+      required: true

--- a/packs/st2-demos/actions/link_flap_remed_workflow.yaml
+++ b/packs/st2-demos/actions/link_flap_remed_workflow.yaml
@@ -1,0 +1,14 @@
+---
+description: Run a series of simulated actions.
+enabled: true
+entry_point: workflows/link_flap_remed_workflow.yaml
+name: link_flap_remed_workflow 
+pack: st2-demos 
+parameters:
+  host:
+    required: true
+    type: string
+  interface:
+    required: true
+    type: string
+runner_type: mistral-v2

--- a/packs/st2-demos/actions/workflows/bgp_down_remed_workflow.yaml
+++ b/packs/st2-demos/actions/workflows/bgp_down_remed_workflow.yaml
@@ -1,0 +1,85 @@
+---
+version: '2.0'
+
+st2-demos.bgp_down_remed_workflow:
+  
+  input:
+    - host
+    - neighbour 
+  tasks:
+
+    notify_on_slack:
+      # [105, 26]
+      action: chatops.post_message
+      input:
+        channel: "lkhtesting"
+        message: "BGP neighbour <% $.neighbour %> just went down on <% $.host %>"
+      on-success:
+        - show_bgp_neighbours
+      on-error:
+        - report_failure
+    show_bgp_neighbours:
+      # [211, 91]
+      action: clicrud.ops_command
+      input:
+        host: <% $.host %>
+        command: "show ip bgp neighbors"
+      on-success:
+        - send_show_bgp_neighbours_to_slack
+      on-error:
+        - report_failure
+    send_show_bgp_neighbours_to_slack:
+      # [360, 210]
+      action: chatops.post_message
+      input:
+        message: <% task(show_bgp_neighbours).result.result %>
+        channel: "lkhtesting"
+      on-success:
+        - show_interface_brief
+      on-error:
+        - report_failure
+    show_interface_brief:
+      # [551, 333]
+      action: clicrud.ops_command
+      input:
+        host: <% $.host %>
+        command: "show ip int br"
+      on-success:
+        - send_show_interface_brief_to_slack
+      on-error:
+        - report_failure
+    send_show_interface_brief_to_slack:
+      # [761, 436]
+      action: chatops.post_message
+      input:
+        channel: "lkhtesting"
+        message: <% task(show_interface_brief).result.result %>
+      on-success:
+        - send_jira_msg_to_slack
+      on-error:
+        - report_failure
+    send_jira_msg_to_slack:
+      # [716, 580]
+      action: chatops.post_message
+      input:
+        message: "Creating a Jira issue for this event!"
+        channel: "lkhtesting"
+      on-success:
+        - create_jira_issue
+      on-error:
+        - report_failure
+    create_jira_issue:
+      # [638, 743]
+      action: jira.create_issue
+      input:
+        type: "IT Help"
+        summary: "BGP neighbour down: <% $.neighbour %> on <% $.host %>"
+        description:  "<% task(show_bgp_neighbours).result.result %>\n<% task(show_interface_brief).result.result %>"
+      on-error:
+        - report_failure
+    report_failure:
+      # [135, 740]
+      action: chatops.post_message
+      input:
+        message: "Something went wrong in BGP down auto-remediation!"
+        channel: "lkhtesting"

--- a/packs/st2-demos/actions/workflows/link_flap_remed_workflow.yaml
+++ b/packs/st2-demos/actions/workflows/link_flap_remed_workflow.yaml
@@ -1,0 +1,105 @@
+---
+version: '2.0'
+
+st2-demos.link_flap_remed_workflow:
+  
+  input:
+    - host
+    - interface
+  tasks:
+
+    notify_on_slack:
+      # [105, 26]
+      action: chatops.post_message
+      input:
+        channel: "lkhtesting"
+        message: "Interface <% $.interface %> just went down on <% $.host %>"
+      on-success:
+        - show_run_interface
+      on-error:
+        - report_failure
+    show_run_interface:
+      # [175, 128]
+      action: clicrud.ops_command
+      input:
+        host: <% $.host %>
+        command: "show run interface <% $.interface %>"
+      on-success:
+        - send_show_run_interface_to_slack
+      on-error:
+        - report_failure
+    send_show_run_interface_to_slack:
+      # [175, 230]
+      action: chatops.post_message
+      input:
+        message: <% task(show_run_interface).result.result %>
+        channel: "lkhtesting"
+      on-success:
+        - bring_up_msg_to_slack
+      on-error:
+        - report_failure
+    bring_up_msg_to_slack:
+      # [245, 332]
+      action: chatops.post_message
+      input:
+        channel: "lkhtesting"
+        message: "Trying to bring up the link <% $.interface %> on <% $.host %>!"
+      on-success:
+        - bring_up_link
+      on-error:
+        - report_failure
+    bring_up_link:
+      # [315, 434]
+      action: clicrud.config_command
+      input:
+        host: <% $.host %>
+        command: ["int <% $.interface %>","shut","no shut"]
+      on-success:
+        - show_interface_detail
+      on-error:
+        - report_failure
+    show_interface_detail:
+      # [385, 536]
+      action: clicrud.ops_command
+      input:
+        host: <% $.host %>
+        command: "show interface <% $.interface %>"
+      on-success:
+        - send_interface_details_to_slack
+      on-error:
+        - report_failure
+    send_interface_details_to_slack:
+      # [455, 638]
+      action: chatops.post_message
+      input:
+        channel: "lkhtesting"
+        message: <% task(show_interface_detail).result.result %>
+      on-success:
+        - send_zendesk_msg_to_slack
+      on-error:
+        - report_failure
+    send_zendesk_msg_to_slack:
+      # [525, 740]
+      action: chatops.post_message
+      input:
+        message: "Creating a Zendesk issue for this event!"
+        channel: "lkhtesting"
+      on-success:
+        - create_zendesk_tkt
+      on-error:
+        - report_failure
+    create_zendesk_tkt:
+      # [595, 842]
+      action: zendesk.create_ticket
+      input:
+        subject: "Link down: <% $.interface %> on <% $.host %>"
+        description:  "<% task(show_run_interface).result.result %>\n<% task(show_interface_detail).result.result %>"
+      on-error:
+        - report_failure
+    report_failure:
+      # [145, 944]
+      action: chatops.post_message
+      input:
+        message: "Something went wrong in link down auto-remediation!"
+        channel: "lkhtesting"
+        

--- a/packs/st2-demos/rules/splunk_bgp_down.yaml
+++ b/packs/st2-demos/rules/splunk_bgp_down.yaml
@@ -1,0 +1,17 @@
+---
+  name: "splunk_bgp_down_webhook_rule"
+  enabled: true
+  description: "Splunk bgp down webhook rule"
+
+  trigger:
+    type: "core.st2.webhook"
+    parameters:
+      url: "splunk_bgp_down"
+
+  criteria: {}
+
+  action:
+    ref: st2-demos.bgp_down_remed_workflow 
+    parameters:
+      host: "{{trigger.body.result.host}}"
+      neighbour: "{{trigger.body.result.neighbour}}"

--- a/packs/st2-demos/rules/splunk_link_flap.yaml
+++ b/packs/st2-demos/rules/splunk_link_flap.yaml
@@ -1,0 +1,17 @@
+---
+  name: "splunk_link_flap_webhook_rule"
+  enabled: true
+  description: "Splunk link flap  webhook rule"
+
+  trigger:
+    type: "core.st2.webhook"
+    parameters:
+      url: "splunk_link_flap"
+
+  criteria: {}
+
+  action:
+    ref: st2-demos.link_flap_remed_workflow
+    parameters:
+      host: "{{trigger.body.result.host}}"
+      interface: "{{trigger.body.result.interface}}" 


### PR DESCRIPTION
This PR is for adding **ST2-Splunk-VDX** integration demo workflows to the *st2-demos* pack. 

Workflows are created for 2 use cases:

1. Auto-remediation for 'link down' event:
Splunk detects link flap event from vdx syslog and does a webhook call to ST2 which then triggers a workflow. Both mistral and action chain based workflows are defined and either can be used as the action for the webhook trigger. Both workflows do the following: 
    - Notifies of event on slack channel
    - Pulls interface config from the switch and posts to slack 
    - Tries to bring the interface back up (using clicrud config command action)
    - Pulls interface details from the switch and posts to slack 
    - Creates a JIRA ticket for the event

1. Auto-remediation for 'BGP peer down' event:
Splunk detects BGP peer down event from vdx syslog and does a webhook call to ST2 which then triggers a workflow. Both mistral and action chain based workflows are defined and either can be used as the action for the webhook trigger. Both workflows do the following: 
    - Notifies of event on slack channel
    - Pulls BGP neighbor info from the switch and posts to slack 
    - Pulls interface info from the switch and posts to slack 
    - Creates a JIRA ticket for the event

Create 2 rules that bind the webhook triggers (for each of the use cases) to the newly defined workflows. 