### PR TITLE
Update rule for deprecated 'system'

### DIFF
--- a/packs/st2-demos/rules/diskspace_remediation.yaml
+++ b/packs/st2-demos/rules/diskspace_remediation.yaml
@@ -16,8 +16,8 @@
         ref: "st2-demos.diskspace_remediation"
         parameters:
             hostname: "{{trigger.client.name}}"
-            directory: "{{system.logs_dir}}"
-            threshold: "{{system.logs_dir_threshold}}"
+            directory: "{{st2kv.system.logs_dir}}"
+            threshold: "{{st2kv.system.logs_dir_threshold}}"
             event_id: "{{trigger.id}}"
             check_name: "{{trigger.check.name}}"
             alert_message: "{{trigger.check.output}}"


### PR DESCRIPTION
Dah.

https://docs.stackstorm.com/upgrade_notes.html#st2-v2-2
> Jinja notations {{user.key}} and {{system.key}} to access datastore items under user and system scopes are now unsuported. Please use {{st2kv.user.key}} and {{st2kv.system.key}} notations instead. Also, please update your StackStorm content (actions, rules and workflows) to use the new notation.