### PR TITLE
Remove stash on demo-reset

### DIFF
--- a/packs/st2-demos/actions/chains/reset_diskspace_demo.yaml
+++ b/packs/st2-demos/actions/chains/reset_diskspace_demo.yaml
@@ -5,7 +5,7 @@
       ref: "victorops.recover_incident"
       params:
         entity: "{{hostname}}"
-        message: "DemoBot is resetting the diskspace demo"
+        message: "I am  resetting the diskspace demo"
       on-success: "write_big_file"
       on-failure: "write_big_file"
     -
@@ -22,4 +22,13 @@
       params:
         check: "diskspace"
         subscribers: "linux"
+      on-success: "remove_stash"
+    - 
+      name: "remove_stash"
+      ref: "sensu.unsilence"
+      params:
+        client: "{{hostname}}.uswest2.stackstorm.net"
+        check: "demo_diskspace"
+
   default: "victorops_recover_incident"
+  


### PR DESCRIPTION
Sensu auto-remediation leaves the stash and it lives forever. To fully reset the demo, need to remove the stash. Thanks @DoriftoShoes for pointing to the right direction.